### PR TITLE
Added in jq dep text

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This tool supports running both from terraform installed on your local machine o
 
 - [Terraform](https://www.terraform.io/downloads.html) - v0.13.4
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.18.8
+- [jq](https://stedolan.github.io/jq/) - v1.6
 - Access to an **Azure Subscription** and **Service Principal** with '*Contributor*' role
 
 #### Docker


### PR DESCRIPTION
Updated the doc to reflect the need for the jq binary when running terraform natively. This is not an issue when running with docker as this already addressed.