### PR TITLE
Fixed dependency issues

### DIFF
--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -4,8 +4,8 @@
 
 # ****************  REQUIRED VARIABLES  ****************
 # These required variables' values MUST be provided by the user
-prefix   = "<prefix-value>"
-location = "<azure-location-value>" # e.g., "eastus2"
+prefix         = "<prefix-value>"
+location       = "<azure-location-value>" # e.g., "eastus2"
 ssh_public_key = "~/.ssh/id_rsa.pub"
 # ****************  REQUIRED VARIABLES  ****************
 
@@ -38,58 +38,58 @@ default_nodepool_vm_type   = "Standard_D8s_v4"
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 2
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=cas:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 2
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
   },
   compute = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 2
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=compute:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 2
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
   },
   connect = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 2
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=connect:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 2
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=connect:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class"        = "connect"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
   },
   stateless = {
-    "machine_type"          = "Standard_D16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 2
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=stateless:NoSchedule"]
+    "machine_type" = "Standard_D16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 2
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
     }
   },
   stateful = {
-    "machine_type"          = "Standard_D8s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 2
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=stateful:NoSchedule"]
+    "machine_type" = "Standard_D8s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 2
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"
     }

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -4,8 +4,8 @@
 
 # ****************  REQUIRED VARIABLES  ****************
 # These required variables' values MUST be provided by the User
-prefix   = "<prefix-value>"
-location = "<azure-location-value>" # e.g., "eastus2"
+prefix         = "<prefix-value>"
+location       = "<azure-location-value>" # e.g., "eastus2"
 ssh_public_key = "~/.ssh/id_rsa.pub"
 # ****************  REQUIRED VARIABLES  ****************
 

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -4,8 +4,8 @@
 
 # ****************  REQUIRED VARIABLES  ****************
 # These required variables' values MUST be provided by the User
-prefix   = "<prefix-value>"
-location = "<azure-location-value>" # e.g., "eastus2"
+prefix         = "<prefix-value>"
+location       = "<azure-location-value>" # e.g., "eastus2"
 ssh_public_key = "~/.ssh/id_rsa.pub"
 # ****************  REQUIRED VARIABLES  ****************
 
@@ -48,58 +48,58 @@ node_pools_availability_zone   = ""
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 1
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=cas:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
   },
   compute = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 1
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=compute:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
   },
   connect = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 1
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=connect:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=connect:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class"        = "connect"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
   },
   stateless = {
-    "machine_type"          = "Standard_D16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 2
-    "max_nodes"             = 2
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=stateless:NoSchedule"]
+    "machine_type" = "Standard_D16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 2
+    "max_nodes"    = 2
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
     }
   },
   stateful = {
-    "machine_type"          = "Standard_D8s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 3
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=stateful:NoSchedule"]
+    "machine_type" = "Standard_D8s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 3
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"
     }
@@ -117,9 +117,9 @@ create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
 nfs_vm_zone          = 1
 
-nfs_raid_disk_size   = 128
-nfs_raid_disk_type   = "Standard_LRS"
-nfs_raid_disk_zones  = ["1"]
+nfs_raid_disk_size  = 128
+nfs_raid_disk_type  = "Standard_LRS"
+nfs_raid_disk_zones = ["1"]
 
 # Azure Monitor
 create_aks_azure_monitor = false

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -4,8 +4,8 @@
 
 # ****************  REQUIRED VARIABLES  ****************
 # These required variables' values MUST be provided by the User
-prefix   = "<prefix-value>"
-location = "<azure-location-value>" # e.g., "eastus2"
+prefix         = "<prefix-value>"
+location       = "<azure-location-value>" # e.g., "eastus2"
 ssh_public_key = "~/.ssh/id_rsa.pub"
 # ****************  REQUIRED VARIABLES  ****************
 
@@ -38,58 +38,58 @@ default_nodepool_vm_type   = "Standard_D8s_v4"
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 1
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=cas:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
   },
   compute = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 1
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=compute:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
   },
   connect = {
-    "machine_type"          = "Standard_E16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 1
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=connect:NoSchedule"]
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=connect:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class"        = "connect"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
   },
   stateless = {
-    "machine_type"          = "Standard_D16s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 2
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=stateless:NoSchedule"]
+    "machine_type" = "Standard_D16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 2
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
     }
   },
   stateful = {
-    "machine_type"          = "Standard_D8s_v3"
-    "os_disk_size"          = 200
-    "min_nodes"             = 1
-    "max_nodes"             = 3
-    "max_pods"              = 110
-    "node_taints"           = ["workload.sas.com/class=stateful:NoSchedule"]
+    "machine_type" = "Standard_D8s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"
     }
@@ -99,7 +99,7 @@ node_pools = {
 # Jump Box
 create_jump_public_ip = true
 jump_vm_admin         = "jumpuser"
-jump_vm_machine_type = "Standard_B2s_v3"
+jump_vm_machine_type  = "Standard_B2s_v3"
 
 # Storage for SAS Viya CAS/Compute
 storage_type = "standard"

--- a/files/sas-iac-buildinfo.yaml.tmpl
+++ b/files/sas-iac-buildinfo.yaml.tmpl
@@ -1,0 +1,15 @@
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: sas-iac-buildinfo
+  namespace: kube-system
+data:
+  git-hash: ${git-hash}
+  timestamp: ${timestamp}
+  iac-tooling: ${iac-tooling}
+  terraform: |-
+    version: ${terraform-version}
+    revision: ${terraform-revision}
+    provider-selections: ${provider-selections}
+    outdated: ${terraform-outdated}

--- a/main.tf
+++ b/main.tf
@@ -203,23 +203,23 @@ module "nfs" {
   source    = "./modules/azurerm_vm"
   create_vm = var.storage_type == "standard" ? true : false
 
-  name                         = "${var.prefix}-nfs"
-  azure_rg_name                = azurerm_resource_group.azure_rg.name
-  azure_rg_location            = var.location
-  proximity_placement_group_id = element(coalescelist(azurerm_proximity_placement_group.proximity.*.id, [""]), 0)
-  vnet_subnet_id               = data.azurerm_subnet.misc-subnet.id
-  machine_type                 = var.nfs_vm_machine_type
-  azure_nsg_id                 = azurerm_network_security_group.nsg.id
-  tags                         = var.tags
-  vm_admin                     = var.nfs_vm_admin
-  vm_zone                      = var.nfs_vm_zone
-  ssh_public_key               = file(var.ssh_public_key)
-  cloud_init                   = data.template_cloudinit_config.nfs.rendered
-  create_public_ip             = var.create_nfs_public_ip
-  data_disk_count              = 4
-  data_disk_size               = var.nfs_raid_disk_size
+  name                           = "${var.prefix}-nfs"
+  azure_rg_name                  = azurerm_resource_group.azure_rg.name
+  azure_rg_location              = var.location
+  proximity_placement_group_id   = element(coalescelist(azurerm_proximity_placement_group.proximity.*.id, [""]), 0)
+  vnet_subnet_id                 = data.azurerm_subnet.misc-subnet.id
+  machine_type                   = var.nfs_vm_machine_type
+  azure_nsg_id                   = azurerm_network_security_group.nsg.id
+  tags                           = var.tags
+  vm_admin                       = var.nfs_vm_admin
+  vm_zone                        = var.nfs_vm_zone
+  ssh_public_key                 = file(var.ssh_public_key)
+  cloud_init                     = data.template_cloudinit_config.nfs.rendered
+  create_public_ip               = var.create_nfs_public_ip
+  data_disk_count                = 4
+  data_disk_size                 = var.nfs_raid_disk_size
   data_disk_storage_account_type = var.nfs_raid_disk_type
-  data_disk_zones              = var.nfs_raid_disk_zones
+  data_disk_zones                = var.nfs_raid_disk_zones
 
   depends_on = [module.vnet, azurerm_resource_group.azure_rg]
 }
@@ -227,7 +227,7 @@ module "nfs" {
 resource "azurerm_network_security_rule" "vm-ssh" {
   name                        = "${var.prefix}-ssh"
   description                 = "Allow SSH from source"
-  count                       = ( ((var.create_jump_public_ip && var.create_jump_vm && (length(local.vm_public_access_cidrs) > 0)) || (var.create_nfs_public_ip && var.storage_type == "standard" && (length(local.vm_public_access_cidrs) > 0))) != 0 ) ? 1 : 0
+  count                       = (((var.create_jump_public_ip && var.create_jump_vm && (length(local.vm_public_access_cidrs) > 0)) || (var.create_nfs_public_ip && var.storage_type == "standard" && (length(local.vm_public_access_cidrs) > 0))) != 0) ? 1 : 0
   priority                    = 120
   direction                   = "Inbound"
   access                      = "Allow"
@@ -390,7 +390,7 @@ resource "local_file" "kubeconfig" {
   content  = module.aks.kube_config
   filename = local.kubeconfig_path
 
-  depends_on = [ module.aks ]
+  depends_on = [module.aks]
 }
 
 data "external" "git_hash" {
@@ -402,32 +402,32 @@ data "external" "iac_tooling_version" {
 }
 
 data "template_file" "sas_iac_buildinfo" {
-   template = file("${path.module}/files/sas-iac-buildinfo.yaml.tmpl")
-   vars = {
-     git-hash            = lookup(data.external.git_hash.result, "git-hash")
-     timestamp           = chomp(timestamp())
-     iac-tooling         = var.iac_tooling
-     terraform-version   = lookup(data.external.iac_tooling_version.result, "terraform_version")
-     provider-selections = lookup(data.external.iac_tooling_version.result, "provider_selections")
-     terraform-revision  = lookup(data.external.iac_tooling_version.result, "terraform_revision")
-     terraform-outdated  = lookup(data.external.iac_tooling_version.result, "terraform_outdated")
-   }
- }
+  template = file("${path.module}/files/sas-iac-buildinfo.yaml.tmpl")
+  vars = {
+    git-hash            = lookup(data.external.git_hash.result, "git-hash")
+    timestamp           = chomp(timestamp())
+    iac-tooling         = var.iac_tooling
+    terraform-version   = lookup(data.external.iac_tooling_version.result, "terraform_version")
+    provider-selections = lookup(data.external.iac_tooling_version.result, "provider_selections")
+    terraform-revision  = lookup(data.external.iac_tooling_version.result, "terraform_revision")
+    terraform-outdated  = lookup(data.external.iac_tooling_version.result, "terraform_outdated")
+  }
+}
 
- resource "local_file" "sas_iac_buildinfo" {
-   content  = data.template_file.sas_iac_buildinfo.rendered
-   filename = "${path.module}/sas_iac_buildinfo.yaml"
- }
+resource "local_file" "sas_iac_buildinfo" {
+  content  = data.template_file.sas_iac_buildinfo.rendered
+  filename = "${path.module}/sas_iac_buildinfo.yaml"
+}
 
- resource "null_resource" "sas_iac_buildinfo" {
-   triggers = {
-     always_run = timestamp()
-   }
-   provisioner "local-exec" {
-     command = <<-EOF
+resource "null_resource" "sas_iac_buildinfo" {
+  triggers = {
+    always_run = timestamp()
+  }
+  provisioner "local-exec" {
+    command = <<-EOF
        kubectl --kubeconfig "${var.prefix}-aks-kubeconfig.conf" apply -f ${path.module}/sas_iac_buildinfo.yaml
      EOF
-   }
+  }
 
-   depends_on = [local_file.kubeconfig, local_file.sas_iac_buildinfo]
- }
+  depends_on = [local_file.kubeconfig, local_file.sas_iac_buildinfo]
+}

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,10 @@ terraform {
       source  = "hashicorp/cloudinit"
       version = "2.1.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.0.2"
+    }
   }
 }
 
@@ -53,6 +57,13 @@ provider "azuread" {
   client_id     = var.client_id
   client_secret = var.client_secret
   tenant_id     = var.tenant_id
+}
+
+provider "kubernetes" {
+  host                   = module.aks.host
+  client_key             = base64decode(module.aks.client_key)
+  client_certificate     = base64decode(module.aks.client_certificate)
+  cluster_ca_certificate = base64decode(module.aks.cluster_ca_certificate)
 }
 
 data "azurerm_subscription" "current" {}
@@ -379,34 +390,22 @@ data "external" "iac_tooling_version" {
   program = ["files/iac_tooling_version.sh"]
 }
 
-data "template_file" "sas_iac_buildinfo" {
-  template = file("${path.module}/files/sas-iac-buildinfo.yaml.tmpl")
-  vars = {
-    git-hash            = lookup(data.external.git_hash.result, "git-hash")
-    timestamp           = chomp(timestamp())
-    iac-tooling         = var.iac_tooling
-    terraform-version   = lookup(data.external.iac_tooling_version.result, "terraform_version")
-    provider-selections = lookup(data.external.iac_tooling_version.result, "provider_selections")
-    terraform-revision  = lookup(data.external.iac_tooling_version.result, "terraform_revision")
-    terraform-outdated  = lookup(data.external.iac_tooling_version.result, "terraform_outdated")
-  }
-}
-
-resource "local_file" "sas_iac_buildinfo" {
-  content  = data.template_file.sas_iac_buildinfo.rendered
-  filename = "${path.module}/sas_iac_buildinfo.yaml"
-}
-
-# https://www.terraform.io/docs/language/resources/provisioners/null_resource.html
-resource "null_resource" "sas_iac_buildinfo" {
-  triggers = {
-    always_run = timestamp()
-  }
-  provisioner "local-exec" {
-    command = <<-EOF
-       kubectl --kubeconfig "${var.prefix}-aks-kubeconfig.conf" apply -f ${path.module}/sas_iac_buildinfo.yaml
-     EOF
+resource "kubernetes_config_map" "sas_iac_buildinfo" {
+  metadata {
+    name      = "sas-iac-buildinfo"
+    namespace = "kube-system"
   }
 
-  depends_on = [local_file.kubeconfig, local_file.sas_iac_buildinfo]
+  data = {
+    git-hash    = lookup(data.external.git_hash.result, "git-hash")
+    iac-tooling = var.iac_tooling
+    terraform   = <<EOT
+version: ${lookup(data.external.iac_tooling_version.result, "terraform_version")}
+revision: ${lookup(data.external.iac_tooling_version.result, "terraform_revision")}
+provider-selections: ${lookup(data.external.iac_tooling_version.result, "provider_selections")}
+outdated: ${lookup(data.external.iac_tooling_version.result, "terraform_outdated")}
+EOT
+  }
+
+  depends_on = [ module.aks ]
 }

--- a/modules/aks_node_pool/main.tf
+++ b/modules/aks_node_pool/main.tf
@@ -11,18 +11,18 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale_node_pool" {
   os_disk_size_gb              = var.os_disk_size
   # TODO: enable after azurerm v2.37.0
   # os_disk_type                 = var.os_disk_type
-  os_type                      = var.os_type
-  enable_auto_scaling          = var.enable_auto_scaling
+  os_type             = var.os_type
+  enable_auto_scaling = var.enable_auto_scaling
   # Still in preview, revisit if needed later - https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools-preview
   # enable_node_public_ip        = var.enable_node_public_ip
-  node_count                   = var.node_count
-  max_count                    = var.max_nodes
-  min_count                    = var.min_nodes
-  max_pods                     = var.max_pods
-  node_labels                  = var.node_labels
-  node_taints                  = var.node_taints
-  orchestrator_version         = var.orchestrator_version
-  tags                         = var.tags
+  node_count           = var.node_count
+  max_count            = var.max_nodes
+  min_count            = var.min_nodes
+  max_pods             = var.max_pods
+  node_labels          = var.node_labels
+  node_taints          = var.node_taints
+  orchestrator_version = var.orchestrator_version
+  tags                 = var.tags
 
   lifecycle {
     ignore_changes = [node_count]
@@ -40,14 +40,14 @@ resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
   os_disk_size_gb              = var.os_disk_size
   # TODO: enable after azurerm v2.37.0
   # os_disk_type                 = var.os_disk_type
-  os_type                      = var.os_type
-  enable_auto_scaling          = var.enable_auto_scaling
-  node_count                   = var.node_count
-  max_count                    = var.max_nodes
-  min_count                    = var.min_nodes
-  max_pods                     = var.max_pods
-  node_labels                  = var.node_labels
-  node_taints                  = var.node_taints
-  orchestrator_version         = var.orchestrator_version
-  tags                         = var.tags
+  os_type              = var.os_type
+  enable_auto_scaling  = var.enable_auto_scaling
+  node_count           = var.node_count
+  max_count            = var.max_nodes
+  min_count            = var.min_nodes
+  max_pods             = var.max_pods
+  node_labels          = var.node_labels
+  node_taints          = var.node_taints
+  orchestrator_version = var.orchestrator_version
+  tags                 = var.tags
 }

--- a/modules/azurerm_netapp/main.tf
+++ b/modules/azurerm_netapp/main.tf
@@ -10,7 +10,6 @@
 # }
 
 resource "azurerm_subnet" "anf" {
-  count                = var.create_netapp ? 1 : 0
   name                 = "${var.prefix}-netapp"
   resource_group_name  = var.resource_group_name
   virtual_network_name = var.vnet_name
@@ -27,7 +26,6 @@ resource "azurerm_subnet" "anf" {
 }
 
 resource "azurerm_netapp_account" "anf" {
-  count               = var.create_netapp ? 1 : 0
   name                = "${var.prefix}-netappaccount"
   location            = var.location
   resource_group_name = var.resource_group_name
@@ -35,26 +33,24 @@ resource "azurerm_netapp_account" "anf" {
 }
 
 resource "azurerm_netapp_pool" "anf" {
-  count               = var.create_netapp ? 1 : 0
   name                = "${var.prefix}-netapppool"
   location            = var.location
   resource_group_name = var.resource_group_name
-  account_name        = azurerm_netapp_account.anf[0].name
+  account_name        = azurerm_netapp_account.anf.name
   service_level       = var.service_level
   size_in_tb          = var.size_in_tb
   tags                = var.tags
 }
 
 resource "azurerm_netapp_volume" "anf" {
-  count               = var.create_netapp ? 1 : 0
   name                = "${var.prefix}-netappvolume"
   location            = var.location
   resource_group_name = var.resource_group_name
-  account_name        = azurerm_netapp_account.anf[0].name
+  account_name        = azurerm_netapp_account.anf.name
   service_level       = var.service_level
   pool_name           = "${var.prefix}-netapppool"
   volume_path         = var.volume_path
-  subnet_id           = azurerm_subnet.anf[0].id
+  subnet_id           = azurerm_subnet.anf.id
   protocols           = var.protocols
   storage_quota_in_gb = var.size_in_tb * 1024
   tags                = var.tags

--- a/modules/azurerm_netapp/outputs.tf
+++ b/modules/azurerm_netapp/outputs.tf
@@ -1,23 +1,23 @@
 output "netapp_subnet" {
-  value = var.create_netapp ? element(coalescelist(azurerm_subnet.anf.*.name, [" "]), 0) : null
+  value = azurerm_subnet.anf.name
 }
 
 output "netapp_account_id" {
-  value = var.create_netapp ? element(coalescelist(azurerm_netapp_account.anf.*.id, [""]), 0) : null
+  value = azurerm_netapp_account.anf.id
 }
 
 output "netapp_pool_id" {
-  value = var.create_netapp ? element(coalescelist(azurerm_netapp_pool.anf.*.id, [""]), 0) : null
+  value = azurerm_netapp_pool.anf.id
 }
 
 output "netapp_export_rule_cidr" {
-  value = var.create_netapp ? element(coalescelist(var.subnet_address_prefix, [""]), 0) : null
+  value = var.subnet_address_prefix
 }
 
 output "netapp_endpoint" {
-  value = var.create_netapp ? element(coalescelist(azurerm_netapp_volume.anf.*.mount_ip_addresses.0, [""]), 0) : null
+  value = azurerm_netapp_volume.anf.mount_ip_addresses.0
 }
 
 output "netapp_path" {
-  value = var.create_netapp ? "/${var.volume_path}" : null
+  value = "/${var.volume_path}"
 }

--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -12,7 +12,6 @@ resource "azurerm_public_ip" "vm_ip" {
 }
 
 resource "azurerm_network_interface" "vm_nic" {
-  count                         = var.create_vm ? 1 : 0
   name                          = "${var.name}-nic"
   location                      = var.azure_rg_location
   resource_group_name           = var.azure_rg_name
@@ -28,35 +27,33 @@ resource "azurerm_network_interface" "vm_nic" {
 }
 
 resource "azurerm_network_interface_security_group_association" "vm_nic_sg" {
-  count                     = var.create_vm ? 1 : 0
-  network_interface_id      = azurerm_network_interface.vm_nic.0.id
+  network_interface_id      = azurerm_network_interface.vm_nic.id
   network_security_group_id = var.azure_nsg_id
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk
 resource "azurerm_managed_disk" "vm_data_disk" {
+  count                = var.data_disk_count
   name                 = format("%s-disk%02d", var.name, count.index + 1)
   location             = var.azure_rg_location
   resource_group_name  = var.azure_rg_name
   storage_account_type = var.data_disk_storage_account_type
   create_option        = "Empty"
   disk_size_gb         = var.data_disk_size
-  count                = var.create_vm ? var.data_disk_count : 0
   zones                = var.data_disk_zones
   tags                 = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "vm_data_disk_attach" {
+  count              = var.data_disk_count
   managed_disk_id    = azurerm_managed_disk.vm_data_disk[count.index].id
-  virtual_machine_id = azurerm_linux_virtual_machine.vm.0.id
+  virtual_machine_id = azurerm_linux_virtual_machine.vm.id
   lun                = count.index + 10
   caching            = var.data_disk_storage_account_type == "UltraSSD_LRS" ? "None" : var.data_disk_caching
-  count              = var.create_vm ? var.data_disk_count : 0
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine
 resource "azurerm_linux_virtual_machine" "vm" {
-  count                        = var.create_vm ? 1 : 0
   name                         = "${var.name}-vm"
   location                     = var.azure_rg_location
   proximity_placement_group_id = var.proximity_placement_group_id == "" ? null : var.proximity_placement_group_id
@@ -69,7 +66,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   custom_data = (var.cloud_init != "" ? var.cloud_init : null)
 
   network_interface_ids = [
-    azurerm_network_interface.vm_nic.0.id,
+    azurerm_network_interface.vm_nic.id,
   ]
 
   admin_ssh_key {

--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_public_ip" "vm_ip" {
   resource_group_name = var.azure_rg_name
   allocation_method   = "Static"
   sku                 = var.vm_zone == null ? "Basic" : "Standard"
-  zones               = var.vm_zone == null ? [] : [ var.vm_zone ]
+  zones               = var.vm_zone == null ? [] : [var.vm_zone]
   tags                = var.tags
 }
 

--- a/modules/azurerm_vm/outputs.tf
+++ b/modules/azurerm_vm/outputs.tf
@@ -1,11 +1,11 @@
 output "private_ip_address" {
-  value = var.create_vm ? element(coalescelist(azurerm_linux_virtual_machine.vm.*.private_ip_address, [""]), 0) : null
+  value = azurerm_linux_virtual_machine.vm.private_ip_address
 }
 
 output "public_ip_address" {
-  value = var.create_vm ? element(coalescelist(azurerm_linux_virtual_machine.vm.*.public_ip_address, [""]), 0) : null
+  value = azurerm_linux_virtual_machine.vm.public_ip_address
 }
 
 output "admin_username" {
-  value = var.create_vm ? element(coalescelist(azurerm_linux_virtual_machine.vm.*.admin_username, [var.vm_admin]), 0) : null
+  value = azurerm_linux_virtual_machine.vm.admin_username
 }

--- a/modules/azurerm_vm/variables.tf
+++ b/modules/azurerm_vm/variables.tf
@@ -71,7 +71,7 @@ variable data_disk_caching {
 }
 
 variable data_disk_storage_account_type {
-  default = "Standard_LRS"
+  default     = "Standard_LRS"
   description = "The type of storage to use for the managed disk. Possible values are Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS."
 }
 
@@ -85,7 +85,7 @@ variable os_disk_size {
 }
 
 variable os_disk_storage_account_type {
-  default = "Standard_LRS"
+  default     = "Standard_LRS"
   description = "The Type of Storage Account which should back this the Internal OS Disk. Possible values are Standard_LRS, StandardSSD_LRS and Premium_LRS. Changing this forces a new resource to be created"
 }
 

--- a/modules/azurerm_vnet/main.tf
+++ b/modules/azurerm_vnet/main.tf
@@ -1,0 +1,40 @@
+# Sourced and modified from https://github.com/Azure/terraform-azurerm-vnet
+
+resource azurerm_virtual_network "vnet" {
+  name                = var.vnet_name
+  resource_group_name = var.resource_group_name #data.azurerm_resource_group.vnet.name
+  location            = var.location #data.azurerm_resource_group.vnet.location
+  address_space       = var.address_space
+  dns_servers         = var.dns_servers
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "subnet" {
+  count                                          = length(var.subnet_names)
+  name                                           = var.subnet_names[count.index]
+  resource_group_name                            = var.resource_group_name #data.azurerm_resource_group.vnet.name
+  virtual_network_name                           = azurerm_virtual_network.vnet.name
+  address_prefixes                               = [var.subnet_prefixes[count.index]]
+  service_endpoints                              = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], null)
+  enforce_private_link_endpoint_network_policies = lookup(var.subnet_enforce_private_link_endpoint_network_policies, var.subnet_names[count.index], false)
+  enforce_private_link_service_network_policies  = lookup(var.subnet_enforce_private_link_service_network_policies, var.subnet_names[count.index], false)
+}
+
+locals {
+  azurerm_subnets = {
+    for index, subnet in azurerm_subnet.subnet :
+    subnet.name => subnet.id
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "vnet" {
+  for_each                  = var.nsg_ids
+  subnet_id                 = local.azurerm_subnets[each.key]
+  network_security_group_id = each.value
+}
+
+resource "azurerm_subnet_route_table_association" "vnet" {
+  for_each       = var.route_tables_ids
+  route_table_id = each.value
+  subnet_id      = local.azurerm_subnets[each.key]
+}

--- a/modules/azurerm_vnet/outputs.tf
+++ b/modules/azurerm_vnet/outputs.tf
@@ -1,0 +1,24 @@
+output "vnet_id" {
+  description = "The id of the newly created vNet"
+  value       = azurerm_virtual_network.vnet.id
+}
+
+output "vnet_name" {
+  description = "The Name of the newly created vNet"
+  value       = azurerm_virtual_network.vnet.name
+}
+
+output "vnet_location" {
+  description = "The location of the newly created vNet"
+  value       = azurerm_virtual_network.vnet.location
+}
+
+output "vnet_address_space" {
+  description = "The address space of the newly created vNet"
+  value       = azurerm_virtual_network.vnet.address_space
+}
+
+output "vnet_subnets" {
+  description = "The ids of subnets created inside the newl vNet"
+  value       = azurerm_subnet.subnet.*.id
+}

--- a/modules/azurerm_vnet/variables.tf
+++ b/modules/azurerm_vnet/variables.tf
@@ -1,0 +1,80 @@
+variable "vnet_name" {
+  description = "Name of the vnet to create"
+  type        = string
+  default     = "acctvnet"
+}
+
+variable "location" {
+  
+}
+variable "resource_group_name" {
+  description = "Name of the resource group to be imported."
+  type        = string
+  default = "vnetst-rg"
+}
+
+variable "address_space" {
+  type        = list(string)
+  description = "The address space that is used by the virtual network."
+  default     = ["10.0.0.0/16"]
+}
+
+# If no values specified, this defaults to Azure DNS 
+variable "dns_servers" {
+  description = "The DNS servers to be used with vNet."
+  type        = list(string)
+  default     = []
+}
+
+variable "subnet_prefixes" {
+  description = "The address prefix to use for the subnet."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "subnet_names" {
+  description = "A list of public subnets inside the vNet."
+  type        = list(string)
+  default     = ["subnet1", "subnet2"]
+}
+
+variable "subnet_service_endpoints" {
+  description = "A map of subnet name to service endpoints to add to the subnet."
+  type        = map(any)
+  default     = {}
+}
+
+variable "subnet_enforce_private_link_endpoint_network_policies" {
+  description = "A map of subnet name to enable/disable private link endpoint network policies on the subnet."
+  type        = map(bool)
+  default     = {}
+}
+
+variable "subnet_enforce_private_link_service_network_policies" {
+  description = "A map of subnet name to enable/disable private link service network policies on the subnet."
+  type        = map(bool)
+  default     = {}
+}
+
+variable "nsg_ids" {
+  description = "A map of subnet name to Network Security Group IDs"
+  type        = map(string)
+
+  default = {
+  }
+}
+
+variable "route_tables_ids" {
+  description = "A map of subnet name to Route table ids"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tags" {
+  description = "The tags to associate with your network and subnets."
+  type        = map(string)
+
+  default = {
+    ENV = "test"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,15 +41,15 @@ output "postgres_server_port" {
 
 # jump server
 output jump_private_ip {
-  value = var.create_jump_vm ? module.jump.private_ip_address : null
+  value = var.create_jump_vm ? element(coalescelist(module.jump.*.private_ip_address, [""] ),0) : null
 }
 
 output jump_public_ip {
-  value = var.create_jump_vm && var.create_jump_public_ip ? module.jump.public_ip_address : null
+  value = var.create_jump_vm && var.create_jump_public_ip ? element(coalescelist(module.jump.*.public_ip_address, [""] ),0) : null
 }
 
 output jump_admin_username {
-  value = var.create_jump_vm ? module.jump.admin_username : null
+  value = var.create_jump_vm ? element(coalescelist(module.jump.*.admin_username, [""] ),0): null
 }
 
 output jump_rwx_filestore_path {
@@ -58,15 +58,15 @@ output jump_rwx_filestore_path {
 
 # nfs server
 output nfs_private_ip {
-  value = var.storage_type == "standard" ? module.nfs.private_ip_address : null
+  value = var.storage_type == "standard" ? element(coalescelist(module.nfs.*.private_ip_address, [""] ),0) : null
 }
 
 output nfs_public_ip {
-  value = var.storage_type == "standard" && var.create_nfs_public_ip ? module.nfs.public_ip_address : null
+  value = var.storage_type == "standard" && var.create_nfs_public_ip ? element(coalescelist(module.nfs.*.public_ip_address, [""] ),0) : null
 }
 
 output nfs_admin_username {
-  value = var.storage_type == "standard" ? module.nfs.admin_username : null
+  value = var.storage_type == "standard" ? element(coalescelist(module.nfs.*.admin_username, [""] ),0) : null
 }
 
 # acr
@@ -111,11 +111,11 @@ output "provider" {
 }
 
 output "rwx_filestore_endpoint" {
-  value = var.storage_type == "ha" ? module.netapp.netapp_endpoint : module.nfs.private_ip_address
+  value = var.storage_type == "ha" ? element(coalescelist(module.netapp.*.netapp_endpoint, [""] ),0) : element(coalescelist(module.nfs.*.private_ip_address, [""] ),0)
 }
 
 output "rwx_filestore_path" {
-  value = var.storage_type == "ha" ? module.netapp.netapp_path : "/export"
+  value = var.storage_type == "ha" ? element(coalescelist(module.netapp.*.netapp_path, [""] ),0) : "/export"
 }
 
 output "rwx_filestore_config" {
@@ -129,7 +129,7 @@ output "rwx_filestore_config" {
     "location" : azurerm_resource_group.azure_rg.location,
     "serviceLevel" : var.netapp_service_level,
     "virtualNetwork" : module.vnet.vnet_name,
-    "subnet" : module.netapp.netapp_subnet,
+    "subnet" : element(coalescelist(module.netapp.*.netapp_subnet, [""] ),0),
     "defaults" : {
       "exportRule" : local.vnet_cidr_block,
     }

--- a/variables.tf
+++ b/variables.tf
@@ -256,6 +256,11 @@ variable "jump_vm_admin" {
   default     = "jumpuser"
 }
 
+variable "jump_vm_zone" {
+  description = "The Zone in which this Virtual Machine should be created. Changing this forces a new resource to be created"
+  default     = null
+}
+
 variable "jump_vm_machine_type" {
   default     = "Standard_B2s_v3"
   description = "SKU which should be used for this Virtual Machine"

--- a/variables.tf
+++ b/variables.tf
@@ -257,7 +257,7 @@ variable "jump_vm_admin" {
 }
 
 variable "jump_vm_machine_type" {
-  default = "Standard_B2s_v3"
+  default     = "Standard_B2s_v3"
   description = "SKU which should be used for this Virtual Machine"
 }
 
@@ -281,7 +281,7 @@ variable "create_nfs_public_ip" {
 }
 
 variable "nfs_vm_machine_type" {
-  default = "Standard_D8s_v4" # "Standard_E8s_v3" "Standard_D8s_v4"
+  default     = "Standard_D8s_v4" # "Standard_E8s_v3" "Standard_D8s_v4"
   description = "SKU which should be used for this Virtual Machine"
 }
 
@@ -301,7 +301,7 @@ variable "nfs_raid_disk_size" {
 }
 
 variable nfs_raid_disk_type {
-  default = "Standard_LRS"
+  default     = "Standard_LRS"
   description = "The type of storage to use for the managed disk. Possible values are Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS."
 
   validation {


### PR DESCRIPTION
close - #106 - remove kubernetes_provider that causes the issue and revert back to template file and null_resource
close - #108 - AKS updates no longer are triggered on changes to `tags`, more on that below, however in a few NFS update paths can hit - https://github.com/Azure/terraform-azurerm-compute/issues/107 
close - #109 - add tags to ACR

Added local module for azurerm_vnet to avoid https://github.com/Azure/terraform-azurerm-vnet/issues/41. In digging through this, it's an issue with multiple data source objects which doesn't have 'tags' attribute. TF sees this as a difference and with `depends_on` does a forced replacement of resources - Subnets, AKS etc. These changes solves any unwanted forced replacement and does an in place update to resources triggered due to changes to 'tags'

 