### PR TITLE
Add --output tsv to TF VAR tenant and subscription IDs

### DIFF
--- a/docs/user/AzureHelpTopics.md
+++ b/docs/user/AzureHelpTopics.md
@@ -35,11 +35,11 @@ You can use the following commands, or alter them as needed to establish the env
 # for example, az account show --query '[environmentName, name, tenantId, user.name]'
 
 # set the tenant ID from a query; validate
-TF_VAR_tenant_id=$(sed -e 's/^"//' -e 's/"$//' <<< $(az account show --query 'tenantId'))
+TF_VAR_tenant_id=$(az account show --query 'tenantId' --output tsv)
 echo $TF_VAR_tenant_id
 
 # set the subscription ID from a query; validate
-TF_VAR_subscription_id=$(sed -e 's/^"//' -e 's/"$//' <<< $(az account show --query 'id'))
+TF_VAR_subscription_id=$(az account show --query 'id' --output tsv)
 echo $TF_VAR_subscription_id
 ```
 

--- a/docs/user/AzureHelpTopics.md
+++ b/docs/user/AzureHelpTopics.md
@@ -35,11 +35,11 @@ You can use the following commands, or alter them as needed to establish the env
 # for example, az account show --query '[environmentName, name, tenantId, user.name]'
 
 # set the tenant ID from a query; validate
-TF_VAR_tenant_id=$(az account show --query 'tenantId')
+TF_VAR_tenant_id=$(sed -e 's/^"//' -e 's/"$//' <<< $(az account show --query 'tenantId'))
 echo $TF_VAR_tenant_id
 
 # set the subscription ID from a query; validate
-TF_VAR_subscription_id=$(az account show --query 'id')
+TF_VAR_subscription_id=$(sed -e 's/^"//' -e 's/"$//' <<< $(az account show --query 'id'))
 echo $TF_VAR_subscription_id
 ```
 


### PR DESCRIPTION
When following the instructions as written, the two variables had quotes around the values, which resulted in errors in the next steps. Adding the sed command to remove leading/trailing double quotes resolved the error.