### PR TITLE
Support BYO vnet located outside the AKS RG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "vnet" {
 
   name                = var.vnet_name
   prefix              = var.prefix
-  resource_group_name = module.resource_group.name
+  resource_group_name = var.vnet_resource_group_name == null ? module.resource_group.name : var.vnet_resource_group_name
   location            = var.location
   subnets             = local.subnets
   existing_subnets    = var.subnet_names

--- a/variables.tf
+++ b/variables.tf
@@ -511,6 +511,12 @@ variable "resource_group_name" {
   description = "Name of pre-exising resource group. Leave blank to have one created"
 }
 
+variable "vnet_resource_group_name" {
+  type    = string
+  default = null
+  description = "Name of pre-exising vnet resource group. Leave blank to have one created"
+}
+
 variable "vnet_name" {
   type    = string
   default = null


### PR DESCRIPTION
This pull request is to allow users of this repo that have an existing vnet in a resource group that is different from the target resource group of the Viya4 AKS cluster and other associated resources.