### PR TITLE
Enable the use of a pre-existing LAW for AKS monitor

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -10,7 +10,7 @@ Supported configuration variables are listed in the tables below.  All variables
     - [Azure Authentication](#azure-authentication)
   - [Admin Access](#admin-access)
   - [Networking](#networking)
-    - [Use Existing](#use-existing)
+    - [Use Existing (BYO)](#use-existing-byo)
   - [General](#general)
   - [Node Pools](#node-pools)
     - [Default Node Pool](#default-node-pool)
@@ -114,14 +114,15 @@ The default values for the `subnets` variable are as follows:
 }
 ```
 
-### Use Existing
+### Use Existing (BYO)
 
-If you want to deploy into an existing resource group, vnet, subnets, or network security group, the variables shown in the following table can be used to define
-the existing resources:
+If you want to deploy into an existing resource group, vnet, subnets, or network security group, log_analytics_workspace the variables shown in the following table can be used to define the existing resources:
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | resource_group_name | Name of pre-existing resource group | string | null | Only required if deploying into existing resource group. |
+| log_analytics_workspace_name | Name of pre-existing log analytics workspace | string | null | Only required if deploying into existing log analytics workspace. Setting this variable will enable AKS monitoring. |
+| log_analytics_workspace_resource_group_name | Name of pre-existing log analytics workspace resource group | string | null | Only required if deploying into existing log analytics workspace that is not located in the `resource_group_name`. |
 | vnet_name | Name of pre-existing vnet | string | null | Only required if deploying into existing vnet. |
 | nsg_name | Name of pre-existing network security group | string | null | Only required if deploying into existing NSG. |
 | subnet_names | Existing subnets mapped to desired usage | map(string) | null | Only required if deploying into existing subnets. See the example that follows. |

--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,12 @@ resource "azurerm_network_security_rule" "acr" {
   depends_on                  = [module.nsg]
 }
 
+data "azurerm_log_analytics_workspace" "byo" {
+  count = var.log_analytics_workspace_name != null ? 1 : 0
+  name                = var.log_analytics_workspace_name
+  resource_group_name = var.log_analytics_workspace_resource_group_name
+}
+
 module "aks" {
   source = "./modules/azure_aks"
 
@@ -231,8 +237,8 @@ module "aks" {
   kubernetes_version                       = var.kubernetes_version
   aks_cluster_endpoint_public_access_cidrs = local.cluster_endpoint_public_access_cidrs
   aks_availability_zones                   = var.default_nodepool_availability_zones
-  aks_oms_enabled                          = var.create_aks_azure_monitor
-  aks_log_analytics_workspace_id           = var.create_aks_azure_monitor ? azurerm_log_analytics_workspace.viya4[0].id : null
+  aks_oms_enabled                          = var.create_aks_azure_monitor || var.log_analytics_workspace_name != null
+  aks_log_analytics_workspace_id           = var.log_analytics_workspace_name != null ? data.azurerm_log_analytics_workspace.byo[0].id : ( var.create_aks_azure_monitor ? azurerm_log_analytics_workspace.viya4[0].id : null )
   aks_network_plugin                       = var.aks_network_plugin
   aks_network_policy                       = var.aks_network_policy
   aks_dns_service_ip                       = var.aks_dns_service_ip

--- a/variables.tf
+++ b/variables.tf
@@ -511,6 +511,18 @@ variable "resource_group_name" {
   description = "Name of pre-exising resource group. Leave blank to have one created"
 }
 
+variable "log_analytics_workspace_name" {
+  type    = string
+  default = null
+  description = "{Optional) ID of pre-exising log analytics workspace"
+}
+
+variable "log_analytics_workspace_resource_group_name" {
+  type    = string
+  default = null
+  description = "{Optional) name of pre-exising log analytics workspace resource group if different than resource_group_name"
+}
+
 variable "vnet_name" {
   type    = string
   default = null


### PR DESCRIPTION
Draft pull request to allow users to leverage a pre-existing log analytics workspace to store the AKS cluster logs instead of creating a new one as part of the deployment.