### PR TITLE
support private_dns_zone_id variable

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -78,6 +78,7 @@ You can use `default_public_access_cidrs` to set a default range for all created
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | vnet_address_space | Address space for created vnet | string | "192.168.0.0/16" | This variable is ignored when vnet_name is set (AKA bring your own vnet). |
+| private_dns_zone_id | Subnets to be created and their settings | string | *null* | https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#private_dns_zone_id |
 | subnets | Subnets to be created and their settings | map(object) | *check below* | This variable is ignored when subnet_names is set (AKA bring your own subnets). All defined subnets must exist within the vnet address space. |
 
 The default values for the `subnets` variable are as follows:

--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,7 @@ module "aks" {
   client_id                                = var.client_id
   client_secret                            = var.client_secret
   aks_private_cluster                      = local.is_private
+  private_dns_zone_id                      = var.private_dns_zone_id 
   cluster_egress_type                      = var.egress_public_ip_name ==  null ? "loadBalancer" : "userDefinedRouting"
   depends_on                               = [module.vnet]
 }

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   kubernetes_version              = var.kubernetes_version
   api_server_authorized_ip_ranges = var.aks_private_cluster ? [] : var.aks_cluster_endpoint_public_access_cidrs
   private_cluster_enabled         = var.aks_private_cluster ? true : false
-  private_dns_zone_id             = var.aks_private_cluster ? "System" : null
+  private_dns_zone_id             = var.private_dns_zone_id 
 
   network_profile {
     network_plugin = var.aks_network_plugin

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -13,6 +13,10 @@ variable "aks_private_cluster" {
   default = false
 }
 
+variable "private_dns_zone_id" {
+  default = null
+}
+
 variable "aks_cluster_node_count" {
   default = 4
 }

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,12 @@ variable "default_nodepool_availability_zones" {
 }
 
 # AKS advanced network config
+variable private_dns_zone_id {
+  description = "Either the ID of Private DNS Zone which should be delegated to this Cluster, System to have AKS manage this or None. In case of None you will need to bring your own DNS server and set up resolving."
+  type = string
+  default = null # take the default (System)
+}
+
 variable "aks_network_plugin" {
   description = "Network plugin to use for networking. Currently supported values are azure and kubenet. Changing this forces a new resource to be created."
   type        = string


### PR DESCRIPTION
This pull request exposes aks' ["private_dns_zone_id"](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#private_dns_zone_id) variable directly to the user.  This is to give the user the option of explicitly choosing between:

* "System":  aks creates dns zone for you
* "None": registers dns name of api server in the customer-managed dns server.  This will expect a customer-managed DNS server to have already manually been attached to the network.
* "[some id]":  The ID of Private DNS Zone which should be delegated to this Cluster.  (tbh I am not really sure what this would look like)

Current behavior in the code base defaults to "null" if not a private cluster or "System" if it is a private cluster.  

https://github.com/sassoftware/viya4-iac-azure/blob/0bda54ae4bd80e9770b3c69478dd3f293dabf4cf/modules/azure_aks/main.tf#L13

**In a situation where customer has configured a VPN connection to their vnet + custom DNS servers for this vnet which are managed by the customer (potentially on-prem DNS servers), then "None" is most likely the desired option.**

"System" is sometimes workable when customer is using their own DNS servers - in this case there must be automation configured to reconcile DNS records from azure to customer dns.  However, in my experience, this reconciliation can exceed the 10 minute timeout window causing terraform to error out and not complete.  

This update will simply default `private_dns_zone_id` to *null* in all cases, and allow user to manually specify `private_dns_zone_id` based on their own understanding of their configuration.  