### PR TITLE
Update Dockerfile - missing bash 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /viya4-iac-azure
 COPY --from=terraform /bin/terraform /bin/terraform
 COPY . .
 
-RUN apk --update --no-cache add git openssh \
+RUN apk --update --no-cache add git bash openssh \
   && curl -sLO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-azure/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \


### PR DESCRIPTION
> No such file or directoryfiles/tools/iac_git_info.sh": env: can't execute 'bash

> No such file or directoryfiles/tools/iac_tooling_version.sh": env: can't execute 'bash