### PR TITLE
(IAC-395) Updated default Kubernetes version from 1.19 -> 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AZURECLI_VERSION=2.24.2
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM mcr.microsoft.com/azure-cli:$AZURECLI_VERSION
-ARG KUBECTL_VERSION=1.19.13
+ARG KUBECTL_VERSION=1.21.7
 
 WORKDIR /viya4-iac-azure
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Access to an **Azure Subscription** and an [**Identity**](./docs/user/TerraformA
 
 #### Terraform Requirements:
 - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.19.13
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.21.7
 - [jq](https://stedolan.github.io/jq/) - v1.6
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure) - (optional - useful as an alternative to the Azure Portal) - v2.24.2
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -163,7 +163,7 @@ Ubuntu 20.04 LTS is the operating system used on the Jump/NFS servers. Ubuntu cr
 | :--- | ---: | ---: | ---: | ---: |
 | partner_id | A GUID that is registered with Microsoft to facilitate partner resource usage attribution | string | "5d27f3ae-e49c-4dea-9aa3-b44e4750cd8c" | Defaults to SAS partner GUID. When you deploy this Terraform configuration, Microsoft can identify the installation of SAS software with the deployed Azure resources. Microsoft can then correlate the resources that are used to support the software. Microsoft collects this information to provide the best experiences with their products and to operate their business. The data is collected and governed by Microsoft's privacy policies, located at https://www.microsoft.com/trustcenter. |
 | create_static_kubeconfig | Allows the user to create a provider / service account-based kubeconfig file | bool | true | A value of `false` will default to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig that uses a `Service Account` and `Cluster Role Binding` to provide credentials. |
-| kubernetes_version | The AKS cluster Kubernetes version | string | "1.19.13" | |
+| kubernetes_version | The AKS cluster Kubernetes version | string | "1.21.7" | |
 | create_jump_vm | Create bastion host | bool | true | |
 | create_jump_public_ip | Add public IP address to the jump VM | bool | true | |
 | jump_vm_admin | Operating system Admin User for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -45,7 +45,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.19.13"
+kubernetes_version         = "1.21.7"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.19.13"
+kubernetes_version         = "1.21.7"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.19.13"
+kubernetes_version         = "1.21.7"
 default_nodepool_min_nodes = 1
 #v3 still has local temp storage
 default_nodepool_vm_type   = "Standard_D2_v3"

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.19.13"
+kubernetes_version         = "1.21.7"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.19.13"
+kubernetes_version         = "1.21.7"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -57,7 +57,7 @@ variable "aks_cluster_max_pods" {
 
 variable kubernetes_version {
   description = "The AKS cluster K8s version"
-  default     = "1.19.13"
+  default     = "1.21.7"
 }
 variable "aks_cluster_endpoint_public_access_cidrs" {
   description = "Kubernetes cluster access IP ranges"

--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,7 @@ variable "default_nodepool_vm_type" {
 }
 variable "kubernetes_version" {
   description = "The AKS cluster K8s version"
-  default     = "1.19.13"
+  default     = "1.21.7"
 }
 
 variable "default_nodepool_max_nodes" {


### PR DESCRIPTION
### Updates to support K8s v1.22. Updated default kubernetes version from 1.19 -> 1.21
- Default 'kubernetes_version' updated to 1.21.7
- All example files update to reflect the same

### Test Coverage:
- Verified on Azure with default K8s v1.21.7, viya4 deployment, logging and monitoring were successful.
