### PR TITLE
(IAC-91) Postgres flexible server support

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -37,7 +37,7 @@ locals {
     k => {
       "server_name" : module.flex_postgresql[k].server_name,
       "fqdn" : module.flex_postgresql[k].server_fqdn,
-      "admin" : "${module.flex_postgresql[k].administrator_login}@${module.flex_postgresql[k].server_name}",
+      "admin" : "${module.flex_postgresql[k].administrator_login}",
       "password" : module.flex_postgresql[k].administrator_password,
       "server_port" : "5432", # TODO - Create a var when supported
       "internal" : false

--- a/locals.tf
+++ b/locals.tf
@@ -33,7 +33,16 @@ locals {
       "ssl_enforcement_enabled" : local.postgres_servers[k].ssl_enforcement_enabled,
       "internal" : false
     }
-  } : {}
+  } : ( length(module.flex_postgresql) != 0 ? { for k,v in module.flex_postgresql :
+    k => {
+      "server_name" : module.flex_postgresql[k].server_name,
+      "fqdn" : module.flex_postgresql[k].server_fqdn,
+      "admin" : "${module.flex_postgresql[k].administrator_login}@${module.flex_postgresql[k].server_name}",
+      "password" : module.flex_postgresql[k].administrator_password,
+      "server_port" : "5432", # TODO - Create a var when supported
+      "internal" : false
+    }
+  } : {} )
 
   # Container Registry
   container_registry_sku = title(var.container_registry_sku)

--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,8 @@ module "postgresql" {
 
   ## TODO : requires specific permissions
   vnet_rules = [{ name = "aks", subnet_id = module.vnet.subnets["aks"].id }, { name = "misc", subnet_id = module.vnet.subnets["misc"].id }]
+  ## TODO: to support Flexible Postgres assign Postgres to a isolated subnet
+  # vnet_rules = [{ name = "aks", subnet_id = module.vnet.subnets["aks"].id }, { name = "postgresql", subnet_id = module.vnet.subnets["postgresql"].id }]
 }
 
 module "flex_postgresql" {
@@ -242,7 +244,7 @@ module "flex_postgresql" {
 
   resource_group_name          = local.aks_rg.name
   location                     = var.location
-  server_name                  = lower("${var.prefix}-${each.key}-pgsql")
+  server_name                  = lower("${var.prefix}-${each.key}") # suffix '-flexpgsql' added in the module
   sku_name                     = each.value.sku_name
   storage_mb                   = each.value.storage_mb
   backup_retention_days        = each.value.backup_retention_days
@@ -250,17 +252,14 @@ module "flex_postgresql" {
   administrator_login          = each.value.administrator_login
   administrator_password       = each.value.administrator_password
   server_version               = each.value.server_version
-  # ssl_enforcement_enabled      = each.value.ssl_enforcement_enabled
   firewall_rule_prefix         = "${var.prefix}-${each.key}-postgres-firewall-"
   firewall_rules               = local.postgres_firewall_rules
   vnet_rule_name_prefix        = "${var.prefix}-${each.key}-postgresql-vnet-rule-"
   postgresql_configurations    = each.value.postgresql_configurations
   tags                         = var.tags
-
-  delegated_subnet_id          = module.vnet.subnets["misc"].id
-  ## TODO : requires specific permissions
-
-  # vnet_rules = [{ name = "aks", subnet_id = module.vnet.subnets["aks"].id }, { name = "misc", subnet_id = module.vnet.subnets["misc"].id }]
+  ## TODO: need to clarify requirements, given this "... private_dns_zone_id will be required when setting a delegated_subnet_id ..."
+  # virtual_network_id           = module.vnet.id
+  # delegated_subnet_id          = module.vnet.subnets["postgresql"].id
 }
 
 module "netapp" {

--- a/modules/azurerm_postgresql_flex/main.tf
+++ b/modules/azurerm_postgresql_flex/main.tf
@@ -1,38 +1,76 @@
-# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server
+# Reference: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server
+
+/***
+NOTE: Based on Azure documentatin - https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-virtual-network-portal
+two networking features are supported - 
+  1. Public access (allowed IP addresses)
+  2. Private access (VNet Integration)
+
+To support #2. VNet Integration, the inputs for Postgres will deviate too far from what is 
+currently supported for single Postgresql server. 
+*/
+
+# resource "azurerm_private_dns_zone" "flexpsql" {
+#   name                = "${var.server_name}.postgres.database.azure.com"
+#   resource_group_name = var.resource_group_name
+# }
+
+# resource "azurerm_private_dns_zone_virtual_network_link" "flexpsql" {
+#   name                  = var.server_name
+#   private_dns_zone_name = azurerm_private_dns_zone.flexpsql.name
+#   virtual_network_id    = var.virtual_network_id
+#   resource_group_name   = var.resource_group_name
+# }
+
 resource "azurerm_postgresql_flexible_server" "flexpsql" {
 
-  name                   = var.server_name
-  location               = var.location
-  resource_group_name    = var.resource_group_name
-  
-  sku_name               = var.sku_name
-  
-  storage_mb             = var.storage_mb
-  backup_retention_days  = var.backup_retention_days
+  name                         = "${var.server_name}-flexpgsql"
+  location                     = var.location
+  resource_group_name          = var.resource_group_name
+  sku_name                     = var.sku_name
+  storage_mb                   = var.storage_mb
+  backup_retention_days        = var.backup_retention_days
   geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+  administrator_login          = var.administrator_login
+  administrator_password       = var.administrator_password
+  version                      = var.server_version
+  tags                         = var.tags
+  # delegated_subnet_id          = var.delegated_subnet_id
+  # private_dns_zone_id          = azurerm_private_dns_zone.flexpsql.id
 
-  administrator_login    = var.administrator_login
-  administrator_password = var.administrator_password
-  version                = var.server_version
-  tags                   = var.tags
-  
-  ## TODO: add required 'private_dns_zone_id' since July 2021
-  # delegated_subnet_id    = var.delegated_subnet_id
+  # depends_on = [azurerm_private_dns_zone_virtual_network_link.flexpsql]
+
+  lifecycle {
+    ignore_changes = [ 
+      # Ignore changes to zone on updates after intial creation
+      zone
+    ]  
+  }
 }
 
-resource "azurerm_postgresql_flexible_server_configuration" "flexpsql_config" {
-  count     = length(keys(var.postgresql_configurations))
-  
+
+resource "azurerm_postgresql_flexible_server_configuration" "flexpsql" {
+  count = length(keys(var.postgresql_configurations))
+
   name      = element(keys(var.postgresql_configurations), count.index)
   server_id = azurerm_postgresql_flexible_server.flexpsql.id
   value     = element(values(var.postgresql_configurations), count.index)
 }
 
-resource "azurerm_postgresql_flexible_server_firewall_rule" "flexpsql_firewall_rules" {
-  count            = length(var.firewall_rules)
-  
+resource "azurerm_postgresql_flexible_server_firewall_rule" "flexpsql" {
+  count = length(var.firewall_rules)
+
   name             = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
   server_id        = azurerm_postgresql_flexible_server.flexpsql.id
-  start_ip_address    = var.firewall_rules[count.index]["start_ip"]
-  end_ip_address      = var.firewall_rules[count.index]["end_ip"]
+  start_ip_address = var.firewall_rules[count.index]["start_ip"]
+  end_ip_address   = var.firewall_rules[count.index]["end_ip"]
+}
+
+# NOTE: This firewall rule enables the flag - "Allow public access from any Azure service within Azure to this server"
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_public" {
+
+  name             = "Allow-public-access-from-any-Azure-service"
+  server_id        = azurerm_postgresql_flexible_server.flexpsql.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
 }

--- a/modules/azurerm_postgresql_flex/main.tf
+++ b/modules/azurerm_postgresql_flex/main.tf
@@ -1,0 +1,38 @@
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server
+resource "azurerm_postgresql_flexible_server" "flexpsql" {
+
+  name                   = var.server_name
+  location               = var.location
+  resource_group_name    = var.resource_group_name
+  
+  sku_name               = var.sku_name
+  
+  storage_mb             = var.storage_mb
+  backup_retention_days  = var.backup_retention_days
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+
+  administrator_login    = var.administrator_login
+  administrator_password = var.administrator_password
+  version                = var.server_version
+  tags                   = var.tags
+  
+  ## TODO: add required 'private_dns_zone_id' since July 2021
+  # delegated_subnet_id    = var.delegated_subnet_id
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "flexpsql_config" {
+  count     = length(keys(var.postgresql_configurations))
+  
+  name      = element(keys(var.postgresql_configurations), count.index)
+  server_id = azurerm_postgresql_flexible_server.flexpsql.id
+  value     = element(values(var.postgresql_configurations), count.index)
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "flexpsql_firewall_rules" {
+  count            = length(var.firewall_rules)
+  
+  name             = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
+  server_id        = azurerm_postgresql_flexible_server.flexpsql.id
+  start_ip_address    = var.firewall_rules[count.index]["start_ip"]
+  end_ip_address      = var.firewall_rules[count.index]["end_ip"]
+}

--- a/modules/azurerm_postgresql_flex/outputs.tf
+++ b/modules/azurerm_postgresql_flex/outputs.tf
@@ -24,5 +24,5 @@ output "server_id" {
 
 output "firewall_rule_ids" {
   description = "The list of all firewall rule resource ids"
-  value       = [azurerm_postgresql_flexible_server_firewall_rule.flexpsql_firewall_rules.*.id]
+  value       = [azurerm_postgresql_flexible_server_firewall_rule.flexpsql.*.id]
 }

--- a/modules/azurerm_postgresql_flex/outputs.tf
+++ b/modules/azurerm_postgresql_flex/outputs.tf
@@ -1,0 +1,28 @@
+output "server_name" {
+  description = "The name of the PostgreSQL server"
+  value       = azurerm_postgresql_flexible_server.flexpsql.name
+}
+
+output "server_fqdn" {
+  description = "The fully qualified domain name (FQDN) of the PostgreSQL server"
+  value       = azurerm_postgresql_flexible_server.flexpsql.fqdn
+}
+
+output "administrator_login" {
+  value = var.administrator_login
+}
+
+output "administrator_password" {
+  value     = var.administrator_password
+  sensitive = true
+}
+
+output "server_id" {
+  description = "The resource id of the PostgreSQL server"
+  value       = azurerm_postgresql_flexible_server.flexpsql.id
+}
+
+output "firewall_rule_ids" {
+  description = "The list of all firewall rule resource ids"
+  value       = [azurerm_postgresql_flexible_server_firewall_rule.flexpsql_firewall_rules.*.id]
+}

--- a/modules/azurerm_postgresql_flex/variables.tf
+++ b/modules/azurerm_postgresql_flex/variables.tf
@@ -8,6 +8,11 @@ variable "location" {
   type        = string
 }
 
+# variable "virtual_network_id" {
+#   description = "The ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created."
+#   type        = string
+# }
+
 variable "server_name" {
   description = "Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created."
   type        = string
@@ -16,7 +21,7 @@ variable "server_name" {
 variable "sku_name" {
   description = "Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the tier + family + cores pattern (e.g. B_Gen4_1, GP_Gen5_8)."
   type        = string
-  default     = "GP_Standard_D16s_v3" 
+  default     = "GP_Standard_D16s_v3"
 }
 
 variable "storage_mb" {
@@ -113,7 +118,7 @@ variable "postgresql_configurations" {
   default     = {}
 }
 
-variable "delegated_subnet_id" {
-  description = "Subnet Id"
-  type        = string
-}
+# variable "delegated_subnet_id" {
+#   description = "Subnet Id"
+#   type        = string
+# }

--- a/modules/azurerm_postgresql_flex/variables.tf
+++ b/modules/azurerm_postgresql_flex/variables.tf
@@ -1,0 +1,119 @@
+variable "resource_group_name" {
+  description = "The name of the resource group in which to create the PostgreSQL Server. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "location" {
+  description = "Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "server_name" {
+  description = "Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "sku_name" {
+  description = "Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the tier + family + cores pattern (e.g. B_Gen4_1, GP_Gen5_8)."
+  type        = string
+  default     = "GP_Standard_D16s_v3" 
+}
+
+variable "storage_mb" {
+  description = "Max storage allowed for a server. Possible values are between 5120 MB(5GB) and 1048576 MB(1TB) for the Basic SKU and between 5120 MB(5GB) and 4194304 MB(4TB) for General Purpose/Memory Optimized SKUs."
+  type        = number
+  default     = 102400
+}
+
+variable "backup_retention_days" {
+  description = "Backup retention days for the server, supported values are between 7 and 35 days."
+  type        = number
+  default     = 7
+}
+
+variable "geo_redundant_backup_enabled" {
+  description = "Enable Geo-redundant or not for server backup. Valid values for this property are Enabled or Disabled, not supported for the basic tier."
+  type        = bool
+  default     = false
+}
+
+variable "administrator_login" {
+  description = "The Administrator Login for the PostgreSQL Server. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "administrator_password" {
+  description = "The Password associated with the administrator_login for the PostgreSQL Server."
+  type        = string
+}
+
+variable "server_version" {
+  description = "Specifies the version of PostgreSQL to use. Valid values are 9.5, 9.6, and 10.0. Changing this forces a new resource to be created."
+  type        = string
+  default     = "11"
+}
+
+variable "public_network_access_enabled" {
+  description = "Whether or not public network access is allowed for this server. Possible values are Enabled and Disabled."
+  type        = bool
+  default     = true
+}
+
+variable "db_names" {
+  description = "The list of names of the PostgreSQL Database, which needs to be a valid PostgreSQL identifier. Changing this forces a new resource to be created."
+  type        = list(string)
+  default     = []
+}
+
+variable "db_charset" {
+  description = "Specifies the Charset for the PostgreSQL Database, which needs to be a valid PostgreSQL Charset. Changing this forces a new resource to be created."
+  type        = string
+  default     = "UTF8"
+}
+
+variable "db_collation" {
+  description = "Specifies the Collation for the PostgreSQL Database, which needs to be a valid PostgreSQL Collation. Note that Microsoft uses different notation - en-US instead of en_US. Changing this forces a new resource to be created."
+  type        = string
+  default     = "English_United States.1252"
+}
+
+variable "firewall_rule_prefix" {
+  description = "Specifies prefix for firewall rule names."
+  type        = string
+  default     = "firewall-"
+}
+
+variable "firewall_rules" {
+  description = "The list of maps, describing firewall rules. Valid map items: name, start_ip, end_ip."
+  type        = list(map(string))
+  default     = []
+}
+
+variable "vnet_rule_name_prefix" {
+  description = "Specifies prefix for vnet rule names."
+  type        = string
+  default     = "postgresql-vnet-rule-"
+}
+
+variable "vnet_rules" {
+  description = "The list of maps, describing vnet rules. Valud map items: name, subnet_id."
+  type        = list(map(string))
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of tags to set on every taggable resources. Empty by default."
+  type        = map(string)
+  default     = {}
+}
+
+variable "postgresql_configurations" {
+  description = "A map with PostgreSQL configurations to enable."
+  type        = map(string)
+  default     = {}
+}
+
+variable "delegated_subnet_id" {
+  description = "Subnet Id"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "aks_cluster_password" {
 #postgres
 
 output "postgres_servers" {
-  value = length(module.postgresql) != 0 ? local.postgres_outputs : null
+  value = length(module.postgresql) != 0 || length(module.flex_postgresql) != 0 ? local.postgres_outputs : null
   sensitive = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -575,7 +575,48 @@ variable "subnets" {
       }
     }
   }
-}
+  # TODO: for Flexible Postgres VNet Integration
+  # default = {
+  #   aks = {
+  #     "prefixes": ["192.168.0.0/23"],
+  #     "service_endpoints": ["Microsoft.Sql"],
+  #     "enforce_private_link_endpoint_network_policies": true,
+  #     "enforce_private_link_service_network_policies": false,
+  #     "service_delegations": {},
+  #   }
+  #   postgresql = {
+  #     "prefixes": ["192.168.2.0/24"],
+  #     "service_endpoints": ["Microsoft.Sql"],
+  #     "enforce_private_link_endpoint_network_policies": true,
+  #     "enforce_private_link_service_network_policies": false,
+  #     "service_delegations": {
+  #       postgresflex = {
+  #         "name"    : "Microsoft.DBforPostgreSQL/flexibleServers"
+  #         "actions" : ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+  #       }
+  #     }
+  #   }
+  #   netapp = {
+  #     "prefixes": ["192.168.3.0/24"],
+  #     "service_endpoints": [],
+  #     "enforce_private_link_endpoint_network_policies": false,
+  #     "enforce_private_link_service_network_policies": false,
+  #     "service_delegations": {
+  #       netapp = {
+  #         "name"    : "Microsoft.Netapp/volumes"
+  #         "actions" : ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+  #       }
+  #     }
+  #   }
+  #   misc = {
+  #     "prefixes": ["192.168.4.0/24"],
+  #     "service_endpoints": ["Microsoft.Sql"],
+  #     "enforce_private_link_endpoint_network_policies": true,
+  #     "enforce_private_link_service_network_policies": false,
+  #     "service_delegations": {},
+  #   }
+  # }
+  }
 
 variable "create_static_kubeconfig" {
   description = "Allows the user to create a provider / service account based kube config file"

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,14 @@ variable "tags" {
 # PostgreSQL
 
 # Defaults
+
+# https://docs.microsoft.com/en-us/azure/postgresql/overview#deployment-models
+variable "postgres_type" {
+  description = "Supported Azure PostgreSQL deployment modes are `single` and `flexible`"
+  type        = string
+  default     = "single"
+}
+
 variable "postgres_server_defaults" {
   description = ""
   type        = any

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.62.0"
+      version = "2.93.0"
     }
     azureread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
[In DRAFT] added changes to support Azure Postgresql Flexible Server for #79 

This PR replaces https://github.com/sassoftware/viya4-iac-azure/pull/171 given the extent of changes to Postgresql since PR 171 was opened. 

Changes here follows this https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-firewall-portal uses 'Public access (allowed IP addresses)' option to configure Postgresql firewall rules for external access and to allow connections from Viya4 pods on Azure AKS and enables https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-manage-firewall-portal#connecting-from-azure. This follows the currently supported pattern for Azure Postgres Single server.

