### PR TITLE
(IAC-407) feature: Enable running static checks in Azure IaC repo via pre-commit tool

### DIFF
--- a/.pre-commit-config_template.yaml
+++ b/.pre-commit-config_template.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for more information
+    # See https://pre-commit.com/hooks.html for more hooks
+repos:
+-  repo: meta
+   hooks:
+   - id: check-hooks-apply
+-  repo: local
+   hooks:
+   - id: hadolint-docker-file-entrypoint
+     name: hadolint
+     entry: docker.io/hadolint/hadolint /bin/hadolint
+     language: docker_image
+     types: [dockerfile]
+   - id: shellcheck-docker-file-entrypoint
+     name: shellcheck
+     entry: docker.io/koalaman/shellcheck
+     language: docker_image
+     types: [shell]
+   - id: tflint-locally-installed
+     name: tflint
+     entry: tflint
+     language: system
+     types: [terraform]
+-  repo: https://github.com/pre-commit/pre-commit-hooks
+   rev: v4.1.0
+   hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-added-large-files
+    - id: check-yaml

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,5 +3,11 @@ config {
 }
 
 plugin "azurerm" {
-  enabled = true
+    enabled = true
+    version = "0.14.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+rule "azurerm_kubernetes_cluster_default_node_pool_invalid_vm_size" {
+  enabled = false
 }


### PR DESCRIPTION
Why:

Wish to enable use of existing linter static checks, and any other new ones from developer sandbox.
In an effort to shift left static lint checks already in place for Azure IaC GitHub repo PR/merges
**Note:** This PR also includes the update for IAC-421 which updates the tflint tool configuration and touches the same file that IAC-407 requires.