### PR TITLE
(IAC-449) Fix location to drop space else deployment fails

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -32,7 +32,7 @@ Terraform input variables can be set in the following ways:
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | prefix | A prefix used in the name of all the Azure resources created by this script. | string | | The prefix string must start with a lowercase letter and contain only lowercase alphanumeric characters and dashes (-), but it cannot end with a dash. |
-| location | The Azure Region to provision all resources in this script. | string | "East US" | |
+| location | The Azure Region to provision all resources in this script. | string | "eastus" | |
 
 ### Azure Authentication
 

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -6,7 +6,7 @@ variable aks_cluster_dns_prefix {}
 
 variable "aks_cluster_location" {
   description = "The Azure Region in which all resources in this example should be provisioned"
-  default     = "East US"
+  default     = "eastus"
 }
 
 variable "aks_private_cluster" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "prefix" {
 }
 variable "location" {
   description = "The Azure Region to provision all resources in this script"
-  default     = "East US"
+  default     = "eastus"
 }
 
 variable "ssh_public_key" {


### PR DESCRIPTION
There is an error in the variables.tf with the default location (=Azure region). When not specifying a location file and using the default your terraform apply will fail like this:
```
│ Error: "resource_group_name" may only contain alphanumeric characters, dash, underscores, parentheses and periods
│
│   with module.aks.data.azurerm_public_ip.cluster_public_ip[0],
│   on modules/azure_aks/main.tf line 111, in data "azurerm_public_ip" "cluster_public_ip":
│  111:  data "azurerm_public_ip" "cluster_public_ip" {
```
The cause of that is on line https://github.com/sassoftware/viya4-iac-azure/blob/main/modules/azure_aks/main.tf#L116 where it says `resource_group_name = "MC_${var.aks_cluster_rg}_${var.aks_cluster_name}_${var.aks_cluster_location}"`

The `var.aks_cluster_location` is built from the location in the variables.tf, what happens is that the resource group name gets a space in it, MC_name-rg_name_East US, which is not allowed. Correct region would be "eastus", which this PR fixes.