### PR TITLE
(IAC-506) Added if-else logic to avoid duplicate exports

### DIFF
--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -56,8 +56,9 @@ runcmd:
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC
   #
-  - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
-  - echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - if [ ${aks_cidr_block} == ${misc_cidr_block} ]; then echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; else echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports && echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; fi
+  # - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  # - echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
   #
   # Restart nfs-server service
   #


### PR DESCRIPTION
The cloud-init assumes the aks and misc subnets will be different but that's not always the case. The cloud-config should check to ensure that duplicate lines don't end up in /etc/exports.

## Changes
Added condition to avoid duplicate exports.

## Tests
- Default cluster creation successful
- BYO cluster creation

** Additionally user verified this in their own testing scenario.
