### PR TITLE
fix: (IAC-506) Modified if-else logic to be readable and avoid duplicates

### DIFF
--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -56,8 +56,9 @@ runcmd:
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC
   #
-  - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
-  - echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - if [ ${aks_cidr_block} == ${misc_cidr_block} ]; then echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; else echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports && echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; fi
+  # - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  # - echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
   #
   # Restart nfs-server service
   #

--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -56,9 +56,13 @@ runcmd:
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC
   #
-  - if [ ${aks_cidr_block} == ${misc_cidr_block} ]; then echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; else echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports && echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; fi
-  # - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
-  # - echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - if [ ${aks_cidr_block} == ${misc_cidr_block} ]; 
+  - then 
+  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports;
+  - else
+  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports && \
+  -   echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports;
+  - fi
   #
   # Restart nfs-server service
   #

--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -56,13 +56,8 @@ runcmd:
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC
   #
-  - if [ ${aks_cidr_block} == ${misc_cidr_block} ]; 
-  - then 
-  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports;
-  - else
-  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports && \
-  -   echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports;
-  - fi
+  - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - if [ ${aks_cidr_block} != ${misc_cidr_block} ]; then echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; fi
   #
   # Restart nfs-server service
   #

--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -56,8 +56,13 @@ runcmd:
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC
   #
-  - echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
-  - if [ ${aks_cidr_block} != ${misc_cidr_block} ]; then echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports; fi
+  - if [ "${aks_cidr_block}" != "${misc_cidr_block}" ]
+  - then
+  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  -   echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - else
+  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  - fi
   #
   # Restart nfs-server service
   #


### PR DESCRIPTION
# Changes:
NFS mount failed when AKS and misc CIDR blocks are the same. To resolve the issue If-else logic was added to avoid the duplicate exports.

Stephen's comment:
I have gone ahead and went back to the clear formatting that was asked for, and tested this change in both situations (VPN cluster on private mode and regular mode). Both seem to work well. Feel free to use this how you want.

# Tests:
Following scenarios were verified, see the internal ticket for details
**Scenario 1**: AKS and misc CIDR block are the same
**Scenario 2**: AKS and misc CIDR block are the different
**Scenario 3**: default setting for AKS and misc CIDR blocks