### PR TITLE
implement sku_tier for IAC-639

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,7 @@ module "aks" {
   aks_cluster_rg                           = local.aks_rg.name
   aks_cluster_rg_id                        = local.aks_rg.id
   aks_cluster_dns_prefix                   = "${var.prefix}-aks"
+  aks_cluster_sku_tier                     = var.sku_tier
   aks_cluster_location                     = var.location
   aks_cluster_node_auto_scaling            = var.default_nodepool_min_nodes == var.default_nodepool_max_nodes ? false : true
   aks_cluster_node_count                   = var.default_nodepool_min_nodes

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -4,6 +4,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   location            = var.aks_cluster_location
   resource_group_name = var.aks_cluster_rg
   dns_prefix          = var.aks_cluster_dns_prefix
+  sku_tier            = var.aks_cluster_sku_tier
   
   # https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
   # az aks get-versions --location eastus -o table

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -4,6 +4,16 @@ variable aks_cluster_rg {}
 variable aks_cluster_rg_id {}
 variable aks_cluster_dns_prefix {}
 
+variable aks_cluster_sku_tier {
+  description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free"
+  default = "Free"
+
+  validation {
+    condition     = contains(["Free", "Paid"],  var.sku_tier)
+    error_message = "ERROR: Valid types are \"Free\" and \"Paid\"!"
+  }
+}
+
 variable "aks_cluster_location" {
   description = "The Azure Region in which all resources in this example should be provisioned"
   default     = "eastus"

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,17 @@ variable "location" {
   default     = "eastus"
 }
 
+variable sku_tier {
+  description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free"
+  default = "Free"
+  type = string 
+
+  validation {
+    condition     = contains(["Free", "Paid"],  var.sku_tier)
+    error_message = "ERROR: Valid types are \"Free\" and \"Paid\"!"
+  }
+}
+
 variable "ssh_public_key" {
   type    = string
   default = "~/.ssh/id_rsa.pub"


### PR DESCRIPTION
This adds sku_tier to variables.tf.  Choosing "Free" (the default) results in a cluster "optimized for availability".  Choosing "Paid" optimizes for availability (and cost more $).  Default behavior does not change.  Tested and working