### PR TITLE
feat: (IAC-583): AKS add support for K8s 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AZURECLI_VERSION=2.24.2
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM mcr.microsoft.com/azure-cli:$AZURECLI_VERSION
-ARG KUBECTL_VERSION=1.22.10
+ARG KUBECTL_VERSION=1.23.8
 
 WORKDIR /viya4-iac-azure
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Access to an **Azure Subscription** and an [**Identity**](./docs/user/TerraformA
 
 #### Terraform Requirements:
 - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.22.10
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.23.8
 - [jq](https://stedolan.github.io/jq/) - v1.6
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure) - (optional - useful as an alternative to the Azure Portal) - v2.24.2
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -163,7 +163,7 @@ Ubuntu 20.04 LTS is the operating system used on the Jump/NFS servers. Ubuntu cr
 | :--- | ---: | ---: | ---: | ---: |
 | partner_id | A GUID that is registered with Microsoft to facilitate partner resource usage attribution | string | "5d27f3ae-e49c-4dea-9aa3-b44e4750cd8c" | Defaults to SAS partner GUID. When you deploy this Terraform configuration, Microsoft can identify the installation of SAS software with the deployed Azure resources. Microsoft can then correlate the resources that are used to support the software. Microsoft collects this information to provide the best experiences with their products and to operate their business. The data is collected and governed by Microsoft's privacy policies, located at https://www.microsoft.com/trustcenter. |
 | create_static_kubeconfig | Allows the user to create a provider / service account-based kubeconfig file | bool | true | A value of `false` will default to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig that uses a `Service Account` and `Cluster Role Binding` to provide credentials. |
-| kubernetes_version | The AKS cluster Kubernetes version | string | "1.22.6" | |
+| kubernetes_version | The AKS cluster Kubernetes version | string | "1.23.8" | |
 | create_jump_vm | Create bastion host | bool | true | |
 | create_jump_public_ip | Add public IP address to the jump VM | bool | true | |
 | jump_vm_admin | Operating system Admin User for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -45,7 +45,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 1
 #v3 still has local temp storage
 default_nodepool_vm_type   = "Standard_D2_v3"

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.22.6"
+kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -57,7 +57,7 @@ variable "aks_cluster_max_pods" {
 
 variable kubernetes_version {
   description = "The AKS cluster K8s version"
-  default     = "1.22.6"
+  default     = "1.23.8"
 }
 variable "aks_cluster_endpoint_public_access_cidrs" {
   description = "Kubernetes cluster access IP ranges"

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -21,6 +21,7 @@ data "template_file" "kubeconfig_provider" {
 
 # 1.24 change: Create service account secret
 resource "kubernetes_secret" "sa_secret" {
+  count = var.create_static_kubeconfig ? 1 : 0
   metadata {
     name      = local.service_account_secret_name
     namespace = var.namespace
@@ -36,7 +37,7 @@ resource "kubernetes_secret" "sa_secret" {
 data "kubernetes_secret" "sa_secret" {
   count = var.create_static_kubeconfig ? 1 : 0
   metadata {
-    name = "${kubernetes_secret.sa_secret.metadata.0.name}"
+    name = "${kubernetes_secret.sa_secret[0].metadata.0.name}"
     namespace = var.namespace
   }
 }
@@ -55,8 +56,8 @@ data "template_file" "kubeconfig_sa" {
   }
 }
 
-## Warning message from hashicorp/terraform-provider-kubernetes is expected 
-# Message: "Warning: 'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above"
+# Starting K8s v1.24+ hashicorp/terraform-provider-kubernetes issues warning message:
+# "Warning: 'default_secret_name' is no longer applicable for Kubernetes 'v1.24.0' and above"
 resource "kubernetes_service_account" "kubernetes_sa" {
   count = var.create_static_kubeconfig ? 1 : 0
   metadata {
@@ -64,7 +65,6 @@ resource "kubernetes_service_account" "kubernetes_sa" {
     namespace = var.namespace
   }
 }
-
 
 resource "kubernetes_cluster_role_binding" "kubernetes_crb" {
   count = var.create_static_kubeconfig ? 1 : 0

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -20,20 +20,6 @@ data "template_file" "kubeconfig_provider" {
 }
 
 # Service Account based kube config data/template/resources
-# 1.24 change: Create service account secret
-resource "kubernetes_secret" "sa_secret" {
-  count = var.create_static_kubeconfig ? 1 : 0
-  metadata {
-    name      = local.service_account_secret_name
-    namespace = var.namespace
-    annotations = {
-      "kubernetes.io/service-account.name" = local.service_account_name
-    }
-  }
-
-  type = "kubernetes.io/service-account-token"
-}
-
 data "template_file" "kubeconfig_sa" {
   count = var.create_static_kubeconfig ? 1 : 0
   template = file("${path.module}/templates/kubeconfig-sa.tmpl")
@@ -46,6 +32,20 @@ data "template_file" "kubeconfig_sa" {
     token        = lookup(kubernetes_secret.sa_secret.0.data,"token", "")
     namespace    = var.namespace
   }
+}
+
+# 1.24 change: Create service account secret
+resource "kubernetes_secret" "sa_secret" {
+  count = var.create_static_kubeconfig ? 1 : 0
+  metadata {
+    name      = local.service_account_secret_name
+    namespace = var.namespace
+    annotations = {
+      "kubernetes.io/service-account.name" = local.service_account_name
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
 }
 
 # Starting K8s v1.24+ hashicorp/terraform-provider-kubernetes issues warning message:

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -19,6 +19,7 @@ data "template_file" "kubeconfig_provider" {
   }
 }
 
+# Service Account based kube config data/template/resources
 # 1.24 change: Create service account secret
 resource "kubernetes_secret" "sa_secret" {
   count = var.create_static_kubeconfig ? 1 : 0
@@ -33,15 +34,6 @@ resource "kubernetes_secret" "sa_secret" {
   type = "kubernetes.io/service-account-token"
 }
 
-# Service Account based kube config data/template/resources
-data "kubernetes_secret" "sa_secret" {
-  count = var.create_static_kubeconfig ? 1 : 0
-  metadata {
-    name = "${kubernetes_secret.sa_secret[0].metadata.0.name}"
-    namespace = var.namespace
-  }
-}
-
 data "template_file" "kubeconfig_sa" {
   count = var.create_static_kubeconfig ? 1 : 0
   template = file("${path.module}/templates/kubeconfig-sa.tmpl")
@@ -50,8 +42,8 @@ data "template_file" "kubeconfig_sa" {
     cluster_name = var.cluster_name
     endpoint     = var.endpoint
     name         = local.service_account_name
-    ca_crt       = base64encode(lookup(data.kubernetes_secret.sa_secret.0.data,"ca.crt", ""))
-    token        = lookup(data.kubernetes_secret.sa_secret.0.data,"token", "")
+    ca_crt       = base64encode(lookup(kubernetes_secret.sa_secret.0.data,"ca.crt", ""))
+    token        = lookup(kubernetes_secret.sa_secret.0.data,"token", "")
     namespace    = var.namespace
   }
 }

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -20,6 +20,16 @@ data "template_file" "kubeconfig_provider" {
 }
 
 # Service Account based kube config data/template/resources
+data "kubernetes_secret" "sa_secret" {
+  count = var.create_static_kubeconfig ? 1 : 0
+  metadata {
+    name      = kubernetes_secret.sa_secret.0.metadata.0.name
+    namespace = var.namespace
+  }
+  
+  depends_on = [kubernetes_secret.sa_secret]
+}
+
 data "template_file" "kubeconfig_sa" {
   count = var.create_static_kubeconfig ? 1 : 0
   template = file("${path.module}/templates/kubeconfig-sa.tmpl")
@@ -28,10 +38,12 @@ data "template_file" "kubeconfig_sa" {
     cluster_name = var.cluster_name
     endpoint     = var.endpoint
     name         = local.service_account_name
-    ca_crt       = base64encode(lookup(kubernetes_secret.sa_secret.0.data,"ca.crt", ""))
-    token        = lookup(kubernetes_secret.sa_secret.0.data,"token", "")
+    ca_crt       = base64encode(lookup(data.kubernetes_secret.sa_secret.0.data,"ca.crt", ""))
+    token        = lookup(data.kubernetes_secret.sa_secret.0.data,"token", "")
     namespace    = var.namespace
   }
+
+  depends_on = [data.kubernetes_secret.sa_secret]
 }
 
 # 1.24 change: Create service account secret
@@ -46,6 +58,8 @@ resource "kubernetes_secret" "sa_secret" {
   }
 
   type = "kubernetes.io/service-account-token"
+
+  depends_on = [kubernetes_service_account.kubernetes_sa]
 }
 
 # Starting K8s v1.24+ hashicorp/terraform-provider-kubernetes issues warning message:

--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,7 @@ variable "default_nodepool_vm_type" {
 }
 variable "kubernetes_version" {
   description = "The AKS cluster K8s version"
-  default     = "1.22.6"
+  default     = "1.23.8"
 }
 
 variable "default_nodepool_max_nodes" {

--- a/versions.tf
+++ b/versions.tf
@@ -37,7 +37,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.3.1"
+      version = "2.12.1"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "2.62.0"
     }
-    azureread = {
+    azuread = {
       source  = "hashicorp/azuread"
       version = "1.5.0"
     }
@@ -37,7 +37,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.12.1"
+      version = "2.13.0"
     }
   }
 }


### PR DESCRIPTION
# Background:
Starting from Kubernetes version `1.24.0` service account token is not automatically generated, thus it has to be created separately. The following resources were updated by the provider `hashicorp/kubernetes` to handle this change in `v2.13.0`: `d/kubernetes_service_account`, `r/kubernetes_default_service_account`, `r/kubernetes_service_account`. For Kubernetes clusters running v1.24+ `default_secret_name` will be empty. A warning message will be printed once any of the above resources are in use. 

# Changes:
- To support 1.24+ Kubernetes version in AKS, secret is manually created for the service account
- The default K8s value is updated from 1.22.6 to 1.23.8
- Minor warning fix for provider `hashicorp/azuread`

# Tests:
1. Verified cluster creation with K8s version: 1.24.0 was successful. Viya deployment was successful and application was accessible
2. Verified cluster was created successfully with the new default K8s version: 1.23.8. Viya deployment was successful and application was accessible
3. Verified cluster creation with K8s version: 1.22.6 was successful. Viya deployment was successful and application was accessible
4. Verified cluster creation with version 1.24.0 and create_static_kubeconfig=false was successful. Provider based kubeconfig was generated and used to deploy Viya successfully.