### PR TITLE
Add variable to control the private_dns_zone_id value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,7 @@ module "aks" {
   aks_network_plugin                       = var.aks_network_plugin
   aks_network_policy                       = var.aks_network_policy
   aks_dns_service_ip                       = var.aks_dns_service_ip
+  aks_private_dns_zone_id                  = var.aks_private_dns_zone_id
   aks_docker_bridge_cidr                   = var.aks_docker_bridge_cidr
   cluster_egress_type                      = local.cluster_egress_type
   aks_pod_cidr                             = var.aks_pod_cidr

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   kubernetes_version              = var.kubernetes_version
   api_server_authorized_ip_ranges = var.aks_cluster_endpoint_public_access_cidrs
   private_cluster_enabled         = var.aks_private_cluster
-  private_dns_zone_id             = var.aks_private_cluster ? "System" : null
+  private_dns_zone_id             = var.aks_private_cluster ? var.aks_private_dns_zone_id : null
 
   network_profile {
     network_plugin = var.aks_network_plugin

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -86,6 +86,16 @@ variable "aks_dns_service_ip" {
   default     = "10.0.0.10"
 }
 
+variable "aks_private_dns_zone_id" {
+  description = "If creating a private cluster, the desired private DNS zone configuration. Either 'System' to have AKS manage this, or 'None'. In case of 'None' you will need to bring your own DNS server. Changing this forces a new resource to be created."
+  type        = string
+  default     = "System"
+  validation {
+    condition     = var.aks_private_dns_zone_id != null ? contains(["System", "None"], var.aks_private_dns_zone_id) : true
+    error_message = "ERROR: Supported values for `aks_private_dns_zone_id` are: System, None."
+  }
+}
+
 variable "aks_docker_bridge_cidr" {
   description = "IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created."
   default     = "172.17.0.1/16"

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,16 @@ variable "aks_dns_service_ip" {
   default     = "10.0.0.10"
 }
 
+variable "aks_private_dns_zone_id" {
+  description = "If creating a private cluster, the desired private DNS zone configuration. Either 'System' to have AKS manage this, or 'None'. In case of 'None' you will need to bring your own DNS server. Changing this forces a new resource to be created."
+  type        = string
+  default     = "System"
+  validation {
+    condition     = var.aks_private_dns_zone_id != null ? contains(["System", "None"], var.aks_private_dns_zone_id) : true
+    error_message = "ERROR: Supported values for `aks_private_dns_zone_id` are: System, None."
+  }
+}
+
 variable "aks_docker_bridge_cidr" {
   description = "IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created."
   default     = "172.17.0.1/16"


### PR DESCRIPTION
For our internal VPNed subscriptions, the use of the hardcoded **System** value for **private_dns_zone_id** does not seem to work. The worker nodes fail to contact the API server with an error similar to:

`server can't find adsmit-foo-aks-38c762d3.48995284-7e91-4ff1-bd6f-2ea6fbf3ae54.privatelink.eastus.azmk8s.io: NXDOMAIN
`

As for why the error occurs, I'm not sure. When set to **System**, a private DNS zone is created with the appropriate A record that points the private FQDN to the internal IP. The DNS zone link to the vnet is also setup. Why this link doesn't seem to be working as expected, I don't know.

The VNETs in our CIS provided VPNed subscriptions have custom DNS servers set, rather than using the **Default (Azure-provided)** option. I'm assuming that's related to the problem. According to the [terraform doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster), setting this value to **None** means that you're bringing your own DNS servers. When set to **None**, no private DNS zone is created, there's apparently no private FQDN, and the public FQDN resolves to the private IP from within the VNET.

I suppose why **System** doesn't work is somewhat irrelevant though. This pull request just makes it something the user can adjust as they wish, rather than having it hardcoded. I also purposely didn't add this variable to the BYO Networking README so it would be considered "use at your own risk".