### PR TITLE
feat: (IAC-91) Support of Azure DB for PostgreSQL flexible server

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 ## Changes for SAS locked down
 - make var for setting outbound_type. Needing for locked down accounts where creating routing tables is not permitted
-- make var for postgres vnet_rules. for vpn subscriptions
+- add Private access (VNet Integration) for flexible postgres
 
 ## Update docs
 - Add this line back into CONFIG-VARS.md @ 122

--- a/locals.tf
+++ b/locals.tf
@@ -20,6 +20,7 @@ locals {
   kubeconfig_path     = var.iac_tooling == "docker" ? "/workspace/${local.kubeconfig_filename}" : local.kubeconfig_filename
 
   # PostgreSQL
+  default_postgres_configuration = [{name: "max_prepared_transactions", value: 1024}]
   postgres_servers        = var.postgres_servers == null ? {} : { for k, v in var.postgres_servers : k => merge(var.postgres_server_defaults, v, ) }
   postgres_firewall_rules = [for addr in local.postgres_public_access_cidrs : { "name" : replace(replace(addr, "/", "_"), ".", "_"), "start_ip" : cidrhost(addr, 0), "end_ip" : cidrhost(addr, abs(pow(2, 32 - split("/", addr)[1]) - 1)) }]
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,11 +1,11 @@
 locals {
-  
+
   # Useful flags
-  ssh_public_key = ( var.create_jump_vm || var.storage_type == "standard"
-                     ? file(var.ssh_public_key)
-                     : null
-                   )
-                   
+  ssh_public_key = (var.create_jump_vm || var.storage_type == "standard"
+    ? file(var.ssh_public_key)
+    : null
+  )
+
   # CIDR/Network
   default_public_access_cidrs          = var.default_public_access_cidrs == null ? [] : var.default_public_access_cidrs
   vm_public_access_cidrs               = var.vm_public_access_cidrs == null ? local.default_public_access_cidrs : var.vm_public_access_cidrs
@@ -13,23 +13,23 @@ locals {
   cluster_endpoint_public_access_cidrs = var.cluster_api_mode == "private" ? [] : (var.cluster_endpoint_public_access_cidrs == null ? local.default_public_access_cidrs : var.cluster_endpoint_public_access_cidrs)
   postgres_public_access_cidrs         = var.postgres_public_access_cidrs == null ? local.default_public_access_cidrs : var.postgres_public_access_cidrs
 
-  subnets = { for k, v in var.subnets : k => v if ! ( k == "netapp" && var.storage_type == "standard")}
+  subnets = { for k, v in var.subnets : k => v if !(k == "netapp" && var.storage_type == "standard") }
 
   # Kubernetes
   kubeconfig_filename = "${var.prefix}-aks-kubeconfig.conf"
   kubeconfig_path     = var.iac_tooling == "docker" ? "/workspace/${local.kubeconfig_filename}" : local.kubeconfig_filename
 
   # PostgreSQL
-  postgres_servers        = var.postgres_servers == null ? {} : { for k, v in var.postgres_servers : k => merge( var.postgres_server_defaults, v, )}
+  postgres_servers        = var.postgres_servers == null ? {} : { for k, v in var.postgres_servers : k => merge(var.postgres_server_defaults, v, ) }
   postgres_firewall_rules = [for addr in local.postgres_public_access_cidrs : { "name" : replace(replace(addr, "/", "_"), ".", "_"), "start_ip" : cidrhost(addr, 0), "end_ip" : cidrhost(addr, abs(pow(2, 32 - split("/", addr)[1]) - 1)) }]
 
-  postgres_outputs = length(module.postgresql) != 0 ? { for k,v in module.postgresql :
+  postgres_outputs = length(module.flex_postgresql) != 0 ? { for k, v in module.flex_postgresql :
     k => {
-      "server_name" : module.postgresql[k].server_name,
-      "fqdn" : module.postgresql[k].server_fqdn,
-      "admin" : "${module.postgresql[k].administrator_login}@${module.postgresql[k].server_name}",
-      "password" : module.postgresql[k].administrator_password,
-      "server_port" : "5432", # TODO - Create a var when supported
+      "server_name" : module.flex_postgresql[k].server_name,
+      "fqdn" : module.flex_postgresql[k].server_fqdn,
+      "admin" : module.flex_postgresql[k].administrator_login,
+      "password" : module.flex_postgresql[k].administrator_password,
+      "server_port" : "5432",
       "ssl_enforcement_enabled" : local.postgres_servers[k].ssl_enforcement_enabled,
       "internal" : false
     }
@@ -38,34 +38,34 @@ locals {
   # Container Registry
   container_registry_sku = title(var.container_registry_sku)
 
-  aks_rg = ( var.resource_group_name == null
-             ? azurerm_resource_group.aks_rg.0
-             : data.azurerm_resource_group.aks_rg.0
-           )
+  aks_rg = (var.resource_group_name == null
+    ? azurerm_resource_group.aks_rg.0
+    : data.azurerm_resource_group.aks_rg.0
+  )
 
-  network_rg = ( var.vnet_resource_group_name == null
-                 ? local.aks_rg
-                 : data.azurerm_resource_group.network_rg.0
-               )
+  network_rg = (var.vnet_resource_group_name == null
+    ? local.aks_rg
+    : data.azurerm_resource_group.network_rg.0
+  )
 
   nsg         = var.nsg_name == null ? azurerm_network_security_group.nsg.0 : data.azurerm_network_security_group.nsg.0
   nsg_rg_name = var.nsg_name == null ? local.aks_rg.name : local.network_rg.name
 
   # Use BYO UAI if given, else create a UAI
-  aks_uai_id = ( var.aks_identity == "uai" 
-                 ? ( var.aks_uai_name == null
-                     ? azurerm_user_assigned_identity.uai.0.id
-                     : data.azurerm_user_assigned_identity.uai.0.id
-                   )
-                 : null
-               )
+  aks_uai_id = (var.aks_identity == "uai"
+    ? (var.aks_uai_name == null
+      ? azurerm_user_assigned_identity.uai.0.id
+      : data.azurerm_user_assigned_identity.uai.0.id
+    )
+    : null
+  )
 
-  cluster_egress_type = ( var.cluster_egress_type == null
-                          ? ( var.egress_public_ip_name == null
-                              ? "loadBalancer"
-                              : "userDefinedRouting"
-                            )
-                          : var.cluster_egress_type
-                        )
+  cluster_egress_type = (var.cluster_egress_type == null
+    ? (var.egress_public_ip_name == null
+      ? "loadBalancer"
+      : "userDefinedRouting"
+    )
+    : var.cluster_egress_type
+  )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -219,8 +219,9 @@ module "flex_postgresql" {
   server_version               = each.value.server_version
   firewall_rule_prefix         = "${var.prefix}-${each.key}-postgres-firewall-"
   firewall_rules               = local.postgres_firewall_rules
-  postgresql_configurations = each.value.postgresql_configurations
-  tags                      = var.tags
+  postgresql_configurations    = !each.value.ssl_enforcement_enabled ? concat(
+    each.value.postgresql_configurations, [{name: "require_secure_transport", value: "OFF"}]) : each.value.postgresql_configurations
+  tags                         = var.tags
 }
 
 module "netapp" {

--- a/main.tf
+++ b/main.tf
@@ -31,8 +31,8 @@ provider "kubernetes" {
 data "azurerm_subscription" "current" {}
 
 data "azurerm_resource_group" "network_rg" {
-  count    = var.vnet_resource_group_name == null ? 0 : 1
-  name     = var.vnet_resource_group_name
+  count = var.vnet_resource_group_name == null ? 0 : 1
+  name  = var.vnet_resource_group_name
 }
 
 resource "azurerm_resource_group" "aks_rg" {
@@ -43,8 +43,8 @@ resource "azurerm_resource_group" "aks_rg" {
 }
 
 data "azurerm_resource_group" "aks_rg" {
-  count    = var.resource_group_name == null ? 0 : 1
-  name     = var.resource_group_name
+  count = var.resource_group_name == null ? 0 : 1
+  name  = var.resource_group_name
 }
 resource "azurerm_proximity_placement_group" "proximity" {
   count = var.node_pools_proximity_placement ? 1 : 0
@@ -89,28 +89,23 @@ module "vnet" {
 }
 
 resource "azurerm_container_registry" "acr" {
-  count                    = var.create_container_registry ? 1 : 0
-  name                     = join("", regexall("[a-zA-Z0-9]+", "${var.prefix}acr")) # alpha numeric characters only are allowed
-  resource_group_name      = local.aks_rg.name
-  location                 = var.location
-  sku                      = local.container_registry_sku
-  admin_enabled            = var.container_registry_admin_enabled
-  
-  #
-  # Moving from deprecated argument, georeplication_locations, but keeping container_registry_geo_replica_locs
-  # for backwards compatability.
-  #
+  count               = var.create_container_registry ? 1 : 0
+  name                = join("", regexall("[a-zA-Z0-9]+", "${var.prefix}acr")) # alpha numeric characters only are allowed
+  resource_group_name = local.aks_rg.name
+  location            = var.location
+  sku                 = local.container_registry_sku
+  admin_enabled       = var.container_registry_admin_enabled
+
   dynamic "georeplications" {
     for_each = (local.container_registry_sku == "Premium" && var.container_registry_geo_replica_locs != null) ? toset(
-      var.container_registry_geo_replica_locs) : []
+    var.container_registry_geo_replica_locs) : []
     content {
-      location                = georeplications.key
-      tags                    = var.tags
+      location = georeplications.key
+      tags     = var.tags
     }
   }
-  tags                     = var.tags
+  tags = var.tags
 }
-
 
 resource "azurerm_network_security_rule" "acr" {
   name                        = "SAS-ACR"
@@ -144,7 +139,7 @@ module "aks" {
   aks_cluster_os_disk_size                 = var.default_nodepool_os_disk_size
   aks_cluster_node_vm_size                 = var.default_nodepool_vm_type
   aks_cluster_node_admin                   = var.node_vm_admin
-  aks_cluster_ssh_public_key               = try( file(var.ssh_public_key), "")
+  aks_cluster_ssh_public_key               = try(file(var.ssh_public_key), "")
   aks_vnet_subnet_id                       = module.vnet.subnets["aks"].id
   kubernetes_version                       = var.kubernetes_version
   aks_cluster_endpoint_public_access_cidrs = var.cluster_api_mode == "private" ? [] : local.cluster_endpoint_public_access_cidrs # "Private cluster cannot be enabled with AuthorizedIPRanges.""
@@ -178,7 +173,7 @@ module "kubeconfig" {
   client_crt               = module.aks.client_certificate
   client_key               = module.aks.client_key
   token                    = module.aks.cluster_password
-  depends_on               = [ module.aks ]
+  depends_on               = [module.aks]
 }
 
 module "node_pools" {
@@ -206,16 +201,15 @@ module "node_pools" {
   tags                         = var.tags
 }
 
-# Module Registry - https://registry.terraform.io/modules/Azure/postgresql/azurerm/2.1.0
-module "postgresql" {
-  source  = "Azure/postgresql/azurerm"
-  version = "2.1.0"
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server
+module "flex_postgresql" {
+  source = "./modules/azurerm_postgresql_flex"
 
-  for_each                     = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
+  for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
 
   resource_group_name          = local.aks_rg.name
   location                     = var.location
-  server_name                  = lower("${var.prefix}-${each.key}-pgsql")
+  server_name                  = lower("${var.prefix}-${each.key}") # suffix '-flexpsql' added in the module
   sku_name                     = each.value.sku_name
   storage_mb                   = each.value.storage_mb
   backup_retention_days        = each.value.backup_retention_days
@@ -223,33 +217,28 @@ module "postgresql" {
   administrator_login          = each.value.administrator_login
   administrator_password       = each.value.administrator_password
   server_version               = each.value.server_version
-  ssl_enforcement_enabled      = each.value.ssl_enforcement_enabled
   firewall_rule_prefix         = "${var.prefix}-${each.key}-postgres-firewall-"
   firewall_rules               = local.postgres_firewall_rules
-  vnet_rule_name_prefix        = "${var.prefix}-${each.key}-postgresql-vnet-rule-"
-  postgresql_configurations    = each.value.postgresql_configurations
-  tags                         = var.tags
-
-  ## TODO : requires specific permissions
-  vnet_rules = [{ name = "aks", subnet_id = module.vnet.subnets["aks"].id }, { name = "misc", subnet_id = module.vnet.subnets["misc"].id }]
+  postgresql_configurations = each.value.postgresql_configurations
+  tags                      = var.tags
 }
 
 module "netapp" {
-  source        = "./modules/azurerm_netapp"
-  count                = var.storage_type == "ha" ? 1 : 0
+  source = "./modules/azurerm_netapp"
+  count  = var.storage_type == "ha" ? 1 : 0
 
-  prefix                = var.prefix
-  resource_group_name   = local.aks_rg.name
-  location              = var.location
-  vnet_name             = module.vnet.name
-  subnet_id             = module.vnet.subnets["netapp"].id
-  service_level         = var.netapp_service_level
-  size_in_tb            = var.netapp_size_in_tb
-  protocols             = var.netapp_protocols
-  volume_path           = "${var.prefix}-${var.netapp_volume_path}"
-  tags                  = var.tags
-  allowed_clients       = concat(module.vnet.subnets["aks"].address_prefixes, module.vnet.subnets["misc"].address_prefixes)
-  depends_on            = [module.vnet]
+  prefix              = var.prefix
+  resource_group_name = local.aks_rg.name
+  location            = var.location
+  vnet_name           = module.vnet.name
+  subnet_id           = module.vnet.subnets["netapp"].id
+  service_level       = var.netapp_service_level
+  size_in_tb          = var.netapp_size_in_tb
+  protocols           = var.netapp_protocols
+  volume_path         = "${var.prefix}-${var.netapp_volume_path}"
+  tags                = var.tags
+  allowed_clients     = concat(module.vnet.subnets["aks"].address_prefixes, module.vnet.subnets["misc"].address_prefixes)
+  depends_on          = [module.vnet]
 }
 
 data "external" "git_hash" {
@@ -262,14 +251,14 @@ data "external" "iac_tooling_version" {
 
 resource "kubernetes_config_map" "sas_iac_buildinfo" {
   metadata {
-     name      = "sas-iac-buildinfo"
-     namespace = "kube-system"
+    name      = "sas-iac-buildinfo"
+    namespace = "kube-system"
   }
 
   data = {
-     git-hash    = lookup(data.external.git_hash.result, "git-hash")
-     iac-tooling = var.iac_tooling
-     terraform   = <<EOT
+    git-hash    = lookup(data.external.git_hash.result, "git-hash")
+    iac-tooling = var.iac_tooling
+    terraform   = <<EOT
 version: ${lookup(data.external.iac_tooling_version.result, "terraform_version")}
 revision: ${lookup(data.external.iac_tooling_version.result, "terraform_revision")}
 provider-selections: ${lookup(data.external.iac_tooling_version.result, "provider_selections")}
@@ -277,5 +266,5 @@ outdated: ${lookup(data.external.iac_tooling_version.result, "terraform_outdated
 EOT
   }
 
-  depends_on = [ module.aks ]
+  depends_on = [module.aks]
 }

--- a/main.tf
+++ b/main.tf
@@ -219,8 +219,8 @@ module "flex_postgresql" {
   server_version               = each.value.server_version
   firewall_rule_prefix         = "${var.prefix}-${each.key}-postgres-firewall-"
   firewall_rules               = local.postgres_firewall_rules
-  postgresql_configurations    = !each.value.ssl_enforcement_enabled ? concat(
-    each.value.postgresql_configurations, [{name: "require_secure_transport", value: "OFF"}]) : each.value.postgresql_configurations
+  postgresql_configurations    = each.value.ssl_enforcement_enabled ? concat(each.value.postgresql_configurations, local.default_postgres_configuration) : concat(
+    each.value.postgresql_configurations, [{name: "require_secure_transport", value: "OFF"}], local.default_postgres_configuration)
   tags                         = var.tags
 }
 

--- a/modules/azurerm_postgresql_flex/main.tf
+++ b/modules/azurerm_postgresql_flex/main.tf
@@ -1,0 +1,57 @@
+###################################################
+### Managed PostgreSQL Flexible server on Azure ###
+###################################################
+#
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server
+#
+
+resource "azurerm_postgresql_flexible_server" "flexpsql" {
+
+  name                         = "${var.server_name}-flexpsql"
+  location                     = var.location
+  resource_group_name          = var.resource_group_name
+  sku_name                     = var.sku_name
+  storage_mb                   = var.storage_mb
+  backup_retention_days        = var.backup_retention_days
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+  administrator_login          = var.administrator_login
+  administrator_password       = var.administrator_password
+  version                      = var.server_version
+  tags                         = var.tags
+
+  lifecycle {
+    ignore_changes = [ 
+      # Ignore changes to zone on updates after intial creation
+      zone
+    ]  
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "flexpsql" {
+  for_each   = {
+    for config in var.postgresql_configurations:
+      config.name => config
+  }
+
+  name       = each.value.name
+  server_id  = azurerm_postgresql_flexible_server.flexpsql.id
+  value      = each.value.value
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "flexpsql" {
+  count = length(var.firewall_rules)
+
+  name             = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
+  server_id        = azurerm_postgresql_flexible_server.flexpsql.id
+  start_ip_address = var.firewall_rules[count.index]["start_ip"]
+  end_ip_address   = var.firewall_rules[count.index]["end_ip"]
+}
+
+# NOTE: This firewall rule enables the flag - "Allow public access from any Azure service within Azure to this server"
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_public" {
+
+  name             = "Allow-public-access-from-any-Azure-service"
+  server_id        = azurerm_postgresql_flexible_server.flexpsql.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}

--- a/modules/azurerm_postgresql_flex/main.tf
+++ b/modules/azurerm_postgresql_flex/main.tf
@@ -39,8 +39,8 @@ resource "azurerm_postgresql_flexible_server_configuration" "flexpsql" {
 }
 
 resource "azurerm_postgresql_flexible_server_firewall_rule" "flexpsql" {
-  count = length(var.firewall_rules)
-
+  count = var.public_network_access_enabled ? length(var.firewall_rules) : 0
+  
   name             = format("%s%s", var.firewall_rule_prefix, lookup(var.firewall_rules[count.index], "name", count.index))
   server_id        = azurerm_postgresql_flexible_server.flexpsql.id
   start_ip_address = var.firewall_rules[count.index]["start_ip"]
@@ -49,6 +49,7 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "flexpsql" {
 
 # NOTE: This firewall rule enables the flag - "Allow public access from any Azure service within Azure to this server"
 resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_public" {
+  count = var.public_network_access_enabled ? 1 : 0
 
   name             = "Allow-public-access-from-any-Azure-service"
   server_id        = azurerm_postgresql_flexible_server.flexpsql.id

--- a/modules/azurerm_postgresql_flex/outputs.tf
+++ b/modules/azurerm_postgresql_flex/outputs.tf
@@ -1,0 +1,28 @@
+output "server_name" {
+  description = "The name of the PostgreSQL server"
+  value       = azurerm_postgresql_flexible_server.flexpsql.name
+}
+
+output "server_fqdn" {
+  description = "The fully qualified domain name (FQDN) of the PostgreSQL server"
+  value       = azurerm_postgresql_flexible_server.flexpsql.fqdn
+}
+
+output "administrator_login" {
+  value = var.administrator_login
+}
+
+output "administrator_password" {
+  value     = var.administrator_password
+  sensitive = true
+}
+
+output "server_id" {
+  description = "The resource id of the PostgreSQL server"
+  value       = azurerm_postgresql_flexible_server.flexpsql.id
+}
+
+output "firewall_rule_ids" {
+  description = "The list of all firewall rule resource ids"
+  value       = [azurerm_postgresql_flexible_server_firewall_rule.flexpsql.*.id]
+}

--- a/modules/azurerm_postgresql_flex/variables.tf
+++ b/modules/azurerm_postgresql_flex/variables.tf
@@ -1,0 +1,87 @@
+variable "resource_group_name" {
+  description = "The name of the Resource Group where the PostgreSQL Flexible Server should exist. Changing this forces a new PostgreSQL Flexible Server to be created."
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure Region where the PostgreSQL Flexible Server should exist. Changing this forces a new PostgreSQL Flexible Server to be created."
+  type        = string
+}
+
+variable "server_name" {
+  description = "The name which should be used for this PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created."
+  type        = string
+}
+
+variable "sku_name" {
+  description = "The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the tier + name pattern (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3)."
+  type        = string
+  default     = "GP_Standard_D16s_v3"
+}
+
+variable "storage_mb" {
+  description = "The max storage allowed for the PostgreSQL Flexible Server. Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432."
+  type        = number
+  default     = 65536
+}
+
+variable "backup_retention_days" {
+  description = "Backup retention days for the server, supported values are between 7 and 35 days."
+  type        = number
+  default     = 7
+}
+
+variable "geo_redundant_backup_enabled" {
+  description = "Enables Geo-Redundant backup on the PostgreSQL Flexible Server. Defaults to false. Changing this forces a new PostgreSQL Flexible Server to be created."
+  type        = bool
+  default     = false
+}
+
+variable "administrator_login" {
+  description = " The Administrator login for the PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created."
+  type        = string
+}
+
+variable "administrator_password" {
+  description = "The Password associated with the administrator_login for the PostgreSQL Flexible Server."
+  type        = string
+}
+
+variable "server_version" {
+  description = "Specifies the version of PostgreSQL to use. The version of PostgreSQL Flexible Server to use. Possible values are 11, 12 and 13. Changing this forces a new PostgreSQL Flexible Server to be created."
+  type        = string
+  default     = "13"
+}
+
+variable "public_network_access_enabled" {
+  description = "Whether or not public network access is allowed for this server. Defaults to true"
+  type        = bool
+  default     = true
+}
+
+variable "firewall_rule_prefix" {
+  description = "Specifies prefix for firewall rule names."
+  type        = string
+  default     = "firewall-"
+}
+
+variable "firewall_rules" {
+  description = "The list of maps, describing firewall rules. Valid map items: name, start_ip, end_ip."
+  type        = list(map(string))
+  default     = []
+}
+
+variable "tags" {
+  description = "A map of tags to set on every taggable resources. Empty by default."
+  type        = map(string)
+  default     = {}
+}
+
+variable "postgresql_configurations" {
+  description = "A map with PostgreSQL configurations to enable."
+  type        = list(object({
+    name = string
+    value = string
+  }))
+  default     = []
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-# #aks
+# aks
 output "aks_host" {
-  value = module.aks.host
+  value     = module.aks.host
   sensitive = true
 }
 
@@ -9,54 +9,54 @@ output "nat_ip" {
 }
 
 output "kube_config" {
-  value = module.kubeconfig.kube_config
+  value     = module.kubeconfig.kube_config
   sensitive = true
 }
 
 output "aks_cluster_node_username" {
-  value = module.aks.cluster_username
+  value     = module.aks.cluster_username
   sensitive = true
 }
 
 output "aks_cluster_password" {
-  value = module.aks.cluster_password
+  value     = module.aks.cluster_password
   sensitive = true
 }
 
-#postgres
+# postgres
 
 output "postgres_servers" {
-  value = length(module.postgresql) != 0 ? local.postgres_outputs : null
+  value     = length(module.flex_postgresql) != 0 ? local.postgres_outputs : null
   sensitive = true
 }
 
 # jump server
-output jump_private_ip {
+output "jump_private_ip" {
   value = var.create_jump_vm ? module.jump.0.private_ip_address : null
 }
 
-output jump_public_ip {
+output "jump_public_ip" {
   value = var.create_jump_vm && var.create_jump_public_ip ? module.jump.0.public_ip_address : null
 }
 
-output jump_admin_username {
+output "jump_admin_username" {
   value = var.create_jump_vm ? module.jump.0.admin_username : null
 }
 
-output jump_rwx_filestore_path {
+output "jump_rwx_filestore_path" {
   value = var.create_jump_vm ? var.jump_rwx_filestore_path : null
 }
 
 # nfs server
-output nfs_private_ip {
+output "nfs_private_ip" {
   value = var.storage_type == "standard" ? module.nfs.0.private_ip_address : null
 }
 
-output nfs_public_ip {
+output "nfs_public_ip" {
   value = var.storage_type == "standard" && var.create_nfs_public_ip ? module.nfs.0.public_ip_address : null
 }
 
-output nfs_admin_username {
+output "nfs_admin_username" {
   value = var.storage_type == "standard" ? module.nfs.0.admin_username : null
 }
 
@@ -78,7 +78,7 @@ output "cr_admin_user" {
 }
 
 output "cr_admin_password" {
-  value = (var.create_container_registry && var.container_registry_admin_enabled) ? element(coalescelist(azurerm_container_registry.acr.*.admin_password, [" "]), 0) : null
+  value     = (var.create_container_registry && var.container_registry_admin_enabled) ? element(coalescelist(azurerm_container_registry.acr.*.admin_password, [" "]), 0) : null
   sensitive = true
 }
 
@@ -103,17 +103,17 @@ output "provider" {
 }
 
 output "rwx_filestore_endpoint" {
-  value = ( var.storage_type == "none"
-            ? null
-            : var.storage_type == "ha" ? module.netapp.0.netapp_endpoint : module.nfs.0.private_ip_address
-          )
+  value = (var.storage_type == "none"
+    ? null
+    : var.storage_type == "ha" ? module.netapp.0.netapp_endpoint : module.nfs.0.private_ip_address
+  )
 }
 
 output "rwx_filestore_path" {
-  value = ( var.storage_type == "none"
-            ? null
-            : var.storage_type == "ha" ? module.netapp.0.netapp_path : "/export"
-          )
+  value = (var.storage_type == "none"
+    ? null
+    : var.storage_type == "ha" ? module.netapp.0.netapp_path : "/export"
+  )
 }
 
 output "rwx_filestore_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,15 @@
 ## Global
-variable client_id {
+variable "client_id" {
   default = ""
 }
-variable client_secret {
+variable "client_secret" {
   default = ""
 }
 
-variable subscription_id {}
-variable tenant_id {}
+variable "subscription_id" {}
+variable "tenant_id" {}
 
-variable use_msi {
+variable "use_msi" {
   description = "Use Managed Identity for Authentication (Azure VMs only)"
   type        = bool
   default     = false
@@ -46,13 +46,11 @@ variable "ssh_public_key" {
   default = "~/.ssh/id_rsa.pub"
 }
 
-
 variable "default_public_access_cidrs" {
   description = "Default list of CIDRs to access created resources."
   type        = list(string)
   default     = null
 }
-
 
 variable "cluster_endpoint_public_access_cidrs" {
   description = "List of CIDRs to access Kubernetes cluster."
@@ -104,7 +102,7 @@ variable "default_nodepool_max_pods" {
 }
 
 variable "default_nodepool_availability_zones" {
-  type    = list
+  type    = list(any)
   default = ["1"]
 }
 
@@ -141,7 +139,6 @@ variable "cluster_egress_type" {
     condition     = var.cluster_egress_type != null ? contains(["loadBalancer", "userDefinedRouting"], var.cluster_egress_type) : true
     error_message = "ERROR: Supported values for `cluster_egress_type` are: loadBalancer, userDefinedRouting."
   }
-
 }
 
 variable "aks_pod_cidr" {
@@ -154,10 +151,10 @@ variable "aks_service_cidr" {
   default     = "10.0.0.0/16"
 }
 
-variable "aks_uai_name"{
+variable "aks_uai_name" {
   description = "User assigned identity name"
-  default = null
-} 
+  default     = null
+}
 
 variable "node_vm_admin" {
   description = "OS Admin User for VMs of AKS Cluster nodes"
@@ -166,7 +163,7 @@ variable "node_vm_admin" {
 
 variable "tags" {
   description = "Map of common tags to be placed on the Resources"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
@@ -177,15 +174,15 @@ variable "postgres_server_defaults" {
   description = ""
   type        = any
   default = {
-    sku_name                     = "GP_Gen5_32"
-    storage_mb                   = 51200
+    sku_name                     = "GP_Standard_D16s_v3"
+    storage_mb                   = 65536
     backup_retention_days        = 7
     geo_redundant_backup_enabled = false
     administrator_login          = "pgadmin"
     administrator_password       = "my$up3rS3cretPassw0rd"
-    server_version               = "11"
+    server_version               = "13"
     ssl_enforcement_enabled      = true
-    postgresql_configurations    = {}
+    postgresql_configurations    = []
   }
 }
 
@@ -197,14 +194,14 @@ variable "postgres_servers" {
 
   # Checking for user provided "default" server
   validation {
-    condition = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? contains(keys(var.postgres_servers), "default") : false : true
+    condition     = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? contains(keys(var.postgres_servers), "default") : false : true
     error_message = "ERROR: The provided map of PostgreSQL server objects does not contain the required 'default' key."
   }
-  
+
   # Checking user provided login
   validation {
     condition = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? alltrue([
-      for k,v in var.postgres_servers : contains(keys(v),"administrator_login") ? ! contains(["azure_superuser", "azure_pg_admin", "admin", "administrator", "root", "guest", "public"], v.administrator_login) && ! can(regex("^pg_", v.administrator_login)) : true
+      for k, v in var.postgres_servers : contains(keys(v), "administrator_login") ? !contains(["azure_superuser", "azure_pg_admin", "admin", "administrator", "root", "guest", "public"], v.administrator_login) && !can(regex("^pg_", v.administrator_login)) : true
     ]) : false : true
     error_message = "ERROR: The admin login name can't be azure_superuser, azure_pg_admin, admin, administrator, root, guest, or public. It can't start with pg_."
   }
@@ -212,7 +209,7 @@ variable "postgres_servers" {
   # Checking user provided password
   validation {
     condition = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? alltrue([
-      for k,v in var.postgres_servers : contains(keys(v),"administrator_password") ? alltrue([
+      for k, v in var.postgres_servers : contains(keys(v), "administrator_password") ? alltrue([
         length(v.administrator_password) > 7,
         length(v.administrator_password) < 129,
         anytrue([
@@ -220,7 +217,7 @@ variable "postgres_servers" {
           (can(regex("[!@#$%^&*(){}[]|<>~`,./_-+=]+", v.administrator_password)) && can(regex("[a-z]+", v.administrator_password)) && can(regex("[A-Z]+", v.administrator_password))),
           (can(regex("[!@#$%^&*(){}[]|<>~`,./_-+=]+", v.administrator_password)) && can(regex("[0-9]+", v.administrator_password)) && can(regex("[A-Z]+", v.administrator_password))),
           (can(regex("[!@#$%^&*(){}[]|<>~`,./_-+=]+", v.administrator_password)) && can(regex("[0-9]+", v.administrator_password)) && can(regex("[a-z]+", v.administrator_password)))
-        ])]) : true 
+      ])]) : true
     ]) : false : true
     error_message = "ERROR: Password is not complex enough. It must contain between 8 and 128 characters. Your password must contain characters from three of the following categories:\n * English uppercase letters,\n * English lowercase letters,\n * numbers (0 through 9), and\n * non-alphanumeric characters (!, $, #, %, etc.)."
   }
@@ -233,7 +230,7 @@ variable "create_jump_vm" {
 
 variable "create_jump_public_ip" {
   default = true
-  type = bool
+  type    = bool
 }
 
 variable "jump_vm_admin" {
@@ -247,7 +244,7 @@ variable "jump_vm_zone" {
 }
 
 variable "jump_vm_machine_type" {
-  default = "Standard_B2s"
+  default     = "Standard_B2s"
   description = "SKU which should be used for this Virtual Machine"
 }
 
@@ -268,7 +265,7 @@ variable "storage_type" {
 
 variable "create_nfs_public_ip" {
   default = false
-  type = bool
+  type    = bool
 }
 
 variable "nfs_vm_machine_type" {
@@ -291,7 +288,7 @@ variable "nfs_raid_disk_size" {
   default     = 128
 }
 
-variable nfs_raid_disk_type {
+variable "nfs_raid_disk_type" {
   default     = "Standard_LRS"
   description = "The type of storage to use for the managed disk. Possible values are Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS."
 
@@ -301,7 +298,7 @@ variable nfs_raid_disk_type {
   }
 }
 
-variable nfs_raid_disk_zone {
+variable "nfs_raid_disk_zone" {
   description = "Specifies the Availability Zone in which this Managed Disk should be located. Changing this property forces a new resource to be created."
   default     = null
 }
@@ -319,12 +316,12 @@ variable "container_registry_admin_enabled" {
   default = false
 }
 variable "container_registry_geo_replica_locs" {
-  type    = list
+  type    = list(any)
   default = null
 }
 
 # Azure NetApp Files
-variable netapp_service_level {
+variable "netapp_service_level" {
   description = "When storage_type=ha, The target performance of the file system. Valid values include Premium, Standard, or Ultra"
   default     = "Premium"
 
@@ -333,7 +330,7 @@ variable netapp_service_level {
     error_message = "ERROR: netapp_service_level - Valid values include - Premium, Standard, or Ultra."
   }
 }
-variable netapp_size_in_tb {
+variable "netapp_size_in_tb" {
   description = "When storage_type=ha, Provisioned size of the pool in TB. Value must be between 4 and 500"
   default     = 4
 
@@ -343,26 +340,26 @@ variable netapp_size_in_tb {
   }
 }
 
-variable netapp_protocols {
+variable "netapp_protocols" {
   description = "The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined it will default to NFSv3. Changing this forces a new resource to be created and data will be lost."
   default     = ["NFSv3"]
 }
-variable netapp_volume_path {
+variable "netapp_volume_path" {
   description = "A unique file path for the volume. Used when creating mount targets. Changing this forces a new resource to be created"
   default     = "export"
 }
 
-variable node_pools_availability_zone {
+variable "node_pools_availability_zone" {
   type    = string
   default = "1"
 }
 
-variable node_pools_proximity_placement {
+variable "node_pools_proximity_placement" {
   type    = bool
   default = false
 }
 
-variable node_pools {
+variable "node_pools" {
   description = "Node pool definitions"
   type = map(object({
     machine_type = string
@@ -474,20 +471,20 @@ variable "log_analytics_solution_promotion_code" {
 
 # BYO
 variable "resource_group_name" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "Name of pre-exising resource group. Leave blank to have one created"
 }
 
 variable "vnet_resource_group_name" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "Name of a pre-exising resource group containing the BYO vnet resource. Leave blank if you are not using a BYO vnet or if the BYO vnet is co-located with the SAS Viya4 AKS cluster."
 }
 
 variable "vnet_name" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "Name of pre-exising vnet. Leave blank to have one created"
 }
 
@@ -498,8 +495,8 @@ variable "vnet_address_space" {
 }
 
 variable "nsg_name" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "Name of pre-exising NSG. Leave blank to have one created"
 }
 
@@ -523,38 +520,38 @@ variable "subnet_names" {
 
 variable "subnets" {
   type = map(object({
-    prefixes                                       = list(string)
-    service_endpoints                              = list(string)
-    private_endpoint_network_policies_enabled      = bool
-    private_link_service_network_policies_enabled  = bool
-    service_delegations                            = map(object({
+    prefixes                                      = list(string)
+    service_endpoints                             = list(string)
+    private_endpoint_network_policies_enabled     = bool
+    private_link_service_network_policies_enabled = bool
+    service_delegations = map(object({
       name    = string
       actions = list(string)
     }))
   }))
   default = {
     aks = {
-      "prefixes": ["192.168.0.0/23"],
-      "service_endpoints": ["Microsoft.Sql"],
-      "private_endpoint_network_policies_enabled": true,
-      "private_link_service_network_policies_enabled": false,
-      "service_delegations": {},
+      "prefixes" : ["192.168.0.0/23"],
+      "service_endpoints" : ["Microsoft.Sql"],
+      "private_endpoint_network_policies_enabled" : true,
+      "private_link_service_network_policies_enabled" : false,
+      "service_delegations" : {},
     }
     misc = {
-      "prefixes": ["192.168.2.0/24"],
-      "service_endpoints": ["Microsoft.Sql"],
-      "private_endpoint_network_policies_enabled": true,
-      "private_link_service_network_policies_enabled": false,
-      "service_delegations": {},
+      "prefixes" : ["192.168.2.0/24"],
+      "service_endpoints" : ["Microsoft.Sql"],
+      "private_endpoint_network_policies_enabled" : true,
+      "private_link_service_network_policies_enabled" : false,
+      "service_delegations" : {},
     }
     netapp = {
-      "prefixes": ["192.168.3.0/24"],
-      "service_endpoints": [],
-      "private_endpoint_network_policies_enabled": false,
-      "private_link_service_network_policies_enabled": false,
-      "service_delegations": {
+      "prefixes" : ["192.168.3.0/24"],
+      "service_endpoints" : [],
+      "private_endpoint_network_policies_enabled" : false,
+      "private_link_service_network_policies_enabled" : false,
+      "service_delegations" : {
         netapp = {
-          "name"    : "Microsoft.Netapp/volumes"
+          "name" : "Microsoft.Netapp/volumes"
           "actions" : ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
         }
       }


### PR DESCRIPTION
# Changes
- Changes made to support the PostgreSQL flexible server for Azure using the [terraform azurerm_postgresql_flexible_server](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server)
- Default `server_version` value updated from 11 to 13. Variable `postgres_server_defaults` adjusted to map version value to 13.
- The user can select any version between 11-14 to suite their SAS Viya deployment requirements.

### Tests
Verified the following deployment scenarios, please see internal ticket for details.

| Scenario | Provider | K8s Version | PG Version | Order | Cadence | Deployment Stabilized | Notes |
|---|---|---|---|---|---|---|---|
| PostgreSQL V11 | Azure | 1.23.8 | 11.16 | * | Fast:2020 | Yes  | |
| PostgreSQL V12 | Azure | 1.23.8 | 12.11 | * | Fast:2020 | Yes |  |
| PostgreSQL V13 | Azure | 1.23.8 | 13.7 | *| Fast:2020 | Yes | New default, did not define server_version in .tfvars |
| PostgreSQL V14 | Azure | 1.23.8 | 14.4 | *| Fast:2020 | Yes | |