### PR TITLE
feat: (IAC-643): Enable specification of azurerm_netapp_volume.anf.network_features

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -295,6 +295,7 @@ When `storage_type=ha` (high availability), [Microsoft Azure NetApp Files](https
 | netapp_size_in_tb | Provisioned size of the pool in TB. Value must be between 4 and 500 | number | 4 | |
 | netapp_protocols | The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined, it defaults to NFSv3. Changing this forces a new resource to be created and data will be lost. | list of strings | ["NFSv3"] | |
 | netapp_volume_path |A unique file path for the volume. Used when creating mount targets. Changing this forces a new resource to be created. | string | "export" | |
+| netapp_network_features |Indicates which network feature to use, accepted values are `Basic` or `Standard`, it defaults to `Basic` if not defined. | string | "Basic" | This is a feature in public preview. For more information about it and how to register, please refer to [Configure network features for an Azure NetApp Files volume](https://docs.microsoft.com/en-us/azure/azure-netapp-files/configure-network-features)|
 
 ## Azure Container Registry (ACR)
 

--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,7 @@ module "netapp" {
   location            = var.location
   vnet_name           = module.vnet.name
   subnet_id           = module.vnet.subnets["netapp"].id
+  network_features    = var.netapp_network_features
   service_level       = var.netapp_service_level
   size_in_tb          = var.netapp_size_in_tb
   protocols           = var.netapp_protocols

--- a/modules/azurerm_netapp/main.tf
+++ b/modules/azurerm_netapp/main.tf
@@ -35,6 +35,7 @@ resource "azurerm_netapp_volume" "anf" {
   pool_name           = "${var.prefix}-netapppool"
   volume_path         = var.volume_path
   subnet_id           = var.subnet_id
+  network_features    = var.network_features
   protocols           = var.protocols
   storage_quota_in_gb = var.size_in_tb * 1024
   tags                = var.tags

--- a/modules/azurerm_netapp/variables.tf
+++ b/modules/azurerm_netapp/variables.tf
@@ -23,6 +23,10 @@ variable "subnet_id" {
   description = "Azure subnet id for Azure NetApp Files"
 }
 
+variable "network_features" {
+  description = "Indicates which network feature to use, accepted values are Basic or Standard, it defaults to Basic if not defined."
+}
+
 # https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-service-levels
 variable "service_level" {
   description = "The target performance of the file system. Valid values include Premium, Standard, or Ultra."

--- a/variables.tf
+++ b/variables.tf
@@ -330,6 +330,7 @@ variable "netapp_service_level" {
     error_message = "ERROR: netapp_service_level - Valid values include - Premium, Standard, or Ultra."
   }
 }
+
 variable "netapp_size_in_tb" {
   description = "When storage_type=ha, Provisioned size of the pool in TB. Value must be between 4 and 500"
   default     = 4
@@ -344,9 +345,15 @@ variable "netapp_protocols" {
   description = "The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined it will default to NFSv3. Changing this forces a new resource to be created and data will be lost."
   default     = ["NFSv3"]
 }
+
 variable "netapp_volume_path" {
   description = "A unique file path for the volume. Used when creating mount targets. Changing this forces a new resource to be created"
   default     = "export"
+}
+
+variable "netapp_network_features" {
+  description = "Indicates which network feature to use, accepted values are Basic or Standard, it defaults to Basic if not defined."
+  default     = "Basic"
 }
 
 variable "node_pools_availability_zone" {

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.21.1"
+      version = "3.26.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
# Changes:
- New variable `netapp_network_features` added to accept the ANF network_features value. Accepted values are `Basic` or `Standard`, default value is set to `Basic`.

- azurerm version updated to latest `v3.26.0` (Since the last update azurerm jumped a few version), no underlying code changes for this version.

# Tests:
Verified following scenarios, see internal ticket for details:

- Scenario 1: netapp_network_features set to Standard
- Scenario 2: netapp_network_features not set, defaults to Basic 
- Scenario 3: SingleStore enabled with netapp_network_features set to Standard
