### PR TITLE
docs: (IAC-403): documentation updates

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -281,7 +281,7 @@ When `storage_type=standard`, a NFS Server VM is created, only when these variab
 | nfs_vm_admin | OS Admin User for the NFS server VM | string | "nfsuser" | |
 | nfs_vm_machine_type | SKU to use for NFS server VM | string | "Standard_D8s_v4" | To check for valid types for your subscription, run: `az vm list-skus --resource-type virtualMachines --subscription $subscription --location $location -o table`|
 | nfs_vm_zone | Zone in which NFS server VM should be created | string | null | |
-| nfs_raid_disk_type | Managed disk types | string | "Standard_LRS" | Supported values: Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS. When using `UltraSSD_LRS`, `nfs_vm_zone` and `nfs_raid_disk_zones` must be specified. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd) for limitations on Availability Zones and VM types. |
+| nfs_raid_disk_type | Managed disk types | string | "Standard_LRS" | Supported values: Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS. When using `UltraSSD_LRS`, `nfs_vm_zone` and `nfs_raid_disk_zone` must be specified. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd) for limitations on Availability Zones and VM types. |
 | nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 128 | |
 | nfs_raid_disk_zone | The Availability Zone in which the Managed Disk should be located. Changing this property forces a new resource to be created. | string | null | |
 

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -111,6 +111,3 @@ nfs_vm_admin         = "nfsuser"
 nfs_vm_machine_type  = "Standard_D8s_v4"
 nfs_raid_disk_size   = 128
 nfs_raid_disk_type   = "Standard_LRS"
-
-# Azure Monitor
-create_aks_azure_monitor = false

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -112,6 +112,3 @@ nfs_vm_admin         = "nfsuser"
 nfs_vm_machine_type  = "Standard_D8s_v4"
 nfs_raid_disk_size   = 128
 nfs_raid_disk_type   = "Standard_LRS"
-
-# Azure Monitor
-create_aks_azure_monitor = false

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -97,6 +97,3 @@ storage_type = "ha"
 # required ONLY when storage_type = ha for Azure NetApp Files service
 netapp_service_level = "Premium"
 netapp_size_in_tb    = 4
-
-# Azure Monitor
-create_aks_azure_monitor = false

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -78,6 +78,3 @@ nfs_vm_admin         = "nfsuser"
 nfs_vm_machine_type  = "Standard_D4s_v4"
 nfs_raid_disk_size   = 128
 nfs_raid_disk_type   = "Standard_LRS"
-
-# Azure Monitor
-create_aks_azure_monitor = false

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -108,7 +108,4 @@ nfs_vm_zone          = 1
 
 nfs_raid_disk_size  = 128
 nfs_raid_disk_type  = "Standard_LRS"
-nfs_raid_disk_zones = ["1"]
-
-# Azure Monitor
-create_aks_azure_monitor = false
+nfs_raid_disk_zone = "1"

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -113,9 +113,6 @@ nfs_vm_machine_type  = "Standard_D8s_v4"
 nfs_raid_disk_size   = 128
 nfs_raid_disk_type   = "Standard_LRS"
 
-# Azure Monitor
-create_aks_azure_monitor = false
-
 # SingleStore configuration
 aks_network_plugin = "azure"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -100,6 +100,3 @@ nfs_vm_admin         = "nfsuser"
 nfs_vm_machine_type  = "Standard_D8s_v4"
 nfs_raid_disk_size   = 128
 nfs_raid_disk_type   = "Standard_LRS"
-
-# Azure Monitor
-create_aks_azure_monitor = false

--- a/variables.tf
+++ b/variables.tf
@@ -432,7 +432,7 @@ variable "node_pools" {
 variable "create_aks_azure_monitor" {
   type        = bool
   description = "Enable Azure Log Analytics agent on AKS cluster"
-  default     = "false"
+  default     = false
 }
 
 variable "enable_log_analytics_workspace" {


### PR DESCRIPTION
# Changes:
- Renamed the missed "nfs_raid_disk_zones" to "nfs_raid_disk_zone"
- Removed the reference of "create_aks_azure_monitor" from example sample files, as this is an undocumented feature.
