### PR TITLE
docs: (IAC-697): Updated the min_nodes value for compute node to 1

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -204,6 +204,8 @@ Additional node pools can be created separate from the default node pool. This i
 
 The default values for the `node_pools` variable are as follows:
 
+**Note**: Maintaining a minimum of 1 node in the pool for `compute` node provides the best customer experience at this time as it makes sure that compute-related pods have the required images pulled and ready for use in the environment.
+
 ```yaml
 {
   cas = {

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -220,7 +220,7 @@ The default values for the `node_pools` variable are as follows:
   compute = {
     "machine_type"          = "Standard_E16s_v3"
     "os_disk_size"          = 200
-    "min_nodes"             = 0
+    "min_nodes"             = 1
     "max_nodes"             = 5
     "max_pods"              = 110
     "node_taints"           = ["workload.sas.com/class=compute:NoSchedule"]

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -204,7 +204,7 @@ Additional node pools can be created separate from the default node pool. This i
 
 The default values for the `node_pools` variable are as follows:
 
-**Note**: Maintaining a minimum of 1 node in the pool for `compute` node provides the best customer experience at this time as it makes sure that compute-related pods have the required images pulled and ready for use in the environment.
+**Note**: SAS recommends that you maintain a minimum of 1 node in the pool for `compute` workloads. This allocation ensures that compute-related pods have the required images pulled and ready for use in the environment..
 
 ```yaml
 {

--- a/variables.tf
+++ b/variables.tf
@@ -394,7 +394,7 @@ variable "node_pools" {
     compute = {
       "machine_type" = "Standard_E16s_v3"
       "os_disk_size" = 200
-      "min_nodes"    = 0
+      "min_nodes"    = 1
       "max_nodes"    = 5
       "max_pods"     = 110
       "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]


### PR DESCRIPTION
# Changes:
Updated the `min_nodes` to 1 for `compute` node in variables.tf and CONFIG-VARS.md node_pool example.

# Tests:
With `min_nodes` set to 1 for `compute` node, verified the cluster was created with 1 compute node and 2 system nodes. After running the viya4-deployment all the pods initially started on `stateful` node, later `cas` node was created. After deployment stabilized logged in to SASStudio, compute context check was successful, SASStudio was usable.