### PR TITLE
feat: (IAC-438) Increase default node count and size for minimal cluster config

### DIFF
--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -33,9 +33,9 @@ container_registry_admin_enabled    = false
 
 # AKS config
 kubernetes_version         = "1.23.8"
-default_nodepool_min_nodes = 1
+default_nodepool_min_nodes = 2
+default_nodepool_vm_type   = "Standard_D8s_v4"
 #v3 still has local temp storage
-default_nodepool_vm_type   = "Standard_D2_v3"
 
 # AKS Node Pools config - minimal
 cluster_node_pool_mode = "minimal"

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -34,7 +34,7 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.23.8"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_D4_v3"
 #v3 still has local temp storage
 
 # AKS Node Pools config - minimal


### PR DESCRIPTION
### Changes
The current minimally sized cluster sample file does not allow for reliable successful deployment of cluster-logging and Viya and sometimes result in a failed logging deployment with errors indicating that insufficient initial cluster resources are the cause.
Increasing the default node count and default vm size in the current minimally sized cluster sample values to 
```
default_nodepool_min_nodes = 2
default_nodepool_vm_type  = "Standard_D4_v3"
```
remedies the problem for a marginally small increase in cost.

### Tests
Ran three consecutive deployments ("cluster-logging,viya,install") against an Azure cluster starting out each time with only the 2 default nodes sized as indicated above. Each time cluster-logging deployed without errors and all logging namespace pods reached the Running status. Internal ticket contains test output detail.