### PR TITLE
feat: (IAC-639):  Implement aks_cluster_sku_tier 

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -173,6 +173,7 @@ Ubuntu 20.04 LTS is the operating system used on the Jump/NFS servers. Ubuntu cr
 | aks_identity | Use UserAssignedIdentity or Service Principal as  [AKS identity](https://docs.microsoft.com/en-us/azure/aks/concepts-identity) | string | "uai" | A value of `uai` wil create a Managed Identity based on the permissions of the authenticated user or use [`AKS_UAI_NAME`](#use-existing), if set. A value of `sp` will use values from [`CLIENT_ID`/`CLIENT_SECRET`](#azure-authentication), if set. |
 | ssh_public_key | File name of public ssh key for jump and nfs VM | string | "~/.ssh/id_rsa.pub" | Required with `create_jump_vm=true` or `storage_type=standard` |
 | cluster_api_mode | Public or private IP for the cluster api | string | "public" | Valid Values: "public", "private" |
+| aks_cluster_sku_tier | Optimizes api server for cost vs availability | string | "Free" | Valid Values:  "Free", "Paid" | 
 
 ## Node Pools
 

--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,7 @@ module "aks" {
   aks_cluster_rg                           = local.aks_rg.name
   aks_cluster_rg_id                        = local.aks_rg.id
   aks_cluster_dns_prefix                   = "${var.prefix}-aks"
+  aks_cluster_sku_tier                     = var.aks_cluster_sku_tier
   aks_cluster_location                     = var.location
   aks_cluster_node_auto_scaling            = var.default_nodepool_min_nodes == var.default_nodepool_max_nodes ? false : true
   aks_cluster_node_count                   = var.default_nodepool_min_nodes

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -4,6 +4,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   location                           = var.aks_cluster_location
   resource_group_name                = var.aks_cluster_rg
   dns_prefix                         = var.aks_cluster_dns_prefix
+  sku_tier                           = var.aks_cluster_sku_tier
   role_based_access_control_enabled  = true
   http_application_routing_enabled   = false
   

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -9,6 +9,16 @@ variable "aks_cluster_location" {
   default     = "eastus"
 }
 
+variable aks_cluster_sku_tier {
+  description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free"
+  default     = "Free"
+
+  validation {
+    condition     = contains(["Free", "Paid"],  var.aks_cluster_sku_tier)
+    error_message = "ERROR: Valid types are \"Free\" and \"Paid\"!"
+  }
+}
+
 variable "aks_private_cluster" {
   default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,17 @@ variable "location" {
   default     = "eastus"
 }
 
+variable aks_cluster_sku_tier {
+  description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free"
+  default = "Free"
+  type = string 
+
+  validation {
+    condition     = contains(["Free", "Paid"],  var.aks_cluster_sku_tier)
+    error_message = "ERROR: Valid types are \"Free\" and \"Paid\"!"
+  }
+}
+
 variable "ssh_public_key" {
   type    = string
   default = "~/.ssh/id_rsa.pub"


### PR DESCRIPTION
This adds aks_cluster_sku_tier to variables.tf. Choosing "Free" (the default) results in a cluster "optimized for availability". Choosing "Paid" optimizes for availability (and cost more $).  (case sensitive).  Default behavior does not change. Tested and working.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#sku_tier 
