### PR TITLE
feat: (IAC-793): support multiple worker/agent availability zones

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -63,7 +63,7 @@ To do set these permissions as part of this Terraform script, specify ranges of 
 
 NOTE: When deploying infrastructure into a private network (e.g. a VPN), with no public endpoints, the options documented in this block are not applicable.
 
-NOTE: The script will either create a new NSG, or use an existing NSG, if specified in the [`nsg_name`](#use-existing) variable. 
+NOTE: The script will either create a new NSG, or use an existing NSG, if specified in the [`nsg_name`](#use-existing) variable.
 
 You can use `default_public_access_cidrs` to set a default range for all created resources. To set different ranges for other resources, define the appropriate variable. Use an empty list `[]` to disallow access explicitly.
 
@@ -75,7 +75,7 @@ You can use `default_public_access_cidrs` to set a default range for all created
 | postgres_public_access_cidrs | IP address ranges allowed to access the Azure PostgreSQL Flexible Server | list of strings || Opens port 5432 by adding Ingress Rule on the NSG. Only used when creating postgres instances. |
 | acr_public_access_cidrs | IP address ranges allowed to access the ACR instance | list of strings || Only used with `create_container_registry=true` |
 
-**NOTE:** In a SCIM environment, the AzureActiveDirectory service tag must be granted access to port 443/HTTPS for the Ingress IP address. 
+**NOTE:** In a SCIM environment, the AzureActiveDirectory service tag must be granted access to port 443/HTTPS for the Ingress IP address.
 
 ## Networking
 
@@ -147,7 +147,7 @@ Example for the `subnet_names` variable:
 ```yaml
 subnet_names = {
   ## Required subnets
-  'aks': '<my_aks_subnet_name>', 
+  'aks': '<my_aks_subnet_name>',
   'misc': '<my_misc_subnet_name>',
 
   ## If using ha storage then the following is also required
@@ -258,7 +258,8 @@ In addition, you can control the placement for the additional node pools using t
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| node_pools_availability_zone | Availability Zone for the additional node pools and the NFS VM, for `storage_type="standard"'| string | "1" | The possible values depend on the region set in the "location" variable. |
+| node_pools_availability_zone | Availability Zone for the additional node pools | string | null | The possible values depend on the region set in the "location" variable.  **Note** Variable superceeded by `node_pools_availability_zones`. |
+| node_pools_availability_zones | Availability Zones for the additional node pools | list of strings | ["1"] | The possible values depend on the region set in the "location" variable. |
 | node_pools_proximity_placement | Co-locates all node pool VMs for improved application performance. | bool | false | Selecting proximity placement imposes an additional constraint on VM creation and can lead to more frequent denials of VM allocation requests. We recommend that you set `node_pools_availability_zone=""` and allocate all required resources at one time by setting `min_nodes` and `max_nodes` to the same value for all node pools.  Additional information: [Proximity Group Placement](./user/ProximityPlacementGroup.md). |
 
 ## Storage

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -258,8 +258,7 @@ In addition, you can control the placement for the additional node pools using t
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| node_pools_availability_zone | Availability Zone for the additional node pools | string | null | The possible values depend on the region set in the "location" variable.  **Note** Variable superceeded by `node_pools_availability_zones`. |
-| node_pools_availability_zones | Availability Zones for the additional node pools | list of strings | ["1"] | The possible values depend on the region set in the "location" variable. |
+| node_pools_availability_zone | Availability Zone for the additional node pools and the NFS VM, for `storage_type="standard"`| string | "1" | The possible values depend on the region set in the "location" variable. |
 | node_pools_proximity_placement | Co-locates all node pool VMs for improved application performance. | bool | false | Selecting proximity placement imposes an additional constraint on VM creation and can lead to more frequent denials of VM allocation requests. We recommend that you set `node_pools_availability_zone=""` and allocate all required resources at one time by setting `min_nodes` and `max_nodes` to the same value for all node pools.  Additional information: [Proximity Group Placement](./user/ProximityPlacementGroup.md). |
 
 ## Storage

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ module "node_pools" {
   max_pods                     = each.value.max_pods == null ? 110 : each.value.max_pods
   node_taints                  = each.value.node_taints
   node_labels                  = each.value.node_labels
-  zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : [var.node_pools_availability_zone]
+  zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zone != null) ? [var.node_pools_availability_zone] : var.node_pools_availability_zones
   proximity_placement_group_id = element(coalescelist(azurerm_proximity_placement_group.proximity.*.id, [""]), 0)
   orchestrator_version         = var.kubernetes_version
   tags                         = var.tags

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ module "node_pools" {
   max_pods                     = each.value.max_pods == null ? 110 : each.value.max_pods
   node_taints                  = each.value.node_taints
   node_labels                  = each.value.node_labels
-  zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zone != "1") ? [var.node_pools_availability_zone] : var.node_pools_availability_zones
+  zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zones != null) ? var.node_pools_availability_zones : [var.node_pools_availability_zone]
   proximity_placement_group_id = element(coalescelist(azurerm_proximity_placement_group.proximity.*.id, [""]), 0)
   orchestrator_version         = var.kubernetes_version
   tags                         = var.tags

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ module "node_pools" {
   max_pods                     = each.value.max_pods == null ? 110 : each.value.max_pods
   node_taints                  = each.value.node_taints
   node_labels                  = each.value.node_labels
-  zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zone != null) ? [var.node_pools_availability_zone] : var.node_pools_availability_zones
+  zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zone != "1") ? [var.node_pools_availability_zone] : var.node_pools_availability_zones
   proximity_placement_group_id = element(coalescelist(azurerm_proximity_placement_group.proximity.*.id, [""]), 0)
   orchestrator_version         = var.kubernetes_version
   tags                         = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -363,8 +363,9 @@ variable "node_pools_availability_zone" {
 }
 
 variable "node_pools_availability_zones" {
+  description = "Specifies a list of Availability Zones in which the Kubernetes Cluster Node Pool should be located. Changing this forces a new Kubernetes Cluster Node Pool to be created."
   type    = list(string)
-  default = ["1"]
+  default = null
 }
 
 variable "node_pools_proximity_placement" {

--- a/variables.tf
+++ b/variables.tf
@@ -359,7 +359,7 @@ variable "netapp_network_features" {
 
 variable "node_pools_availability_zone" {
   type    = string
-  default = null
+  default = "1"
 }
 
 variable "node_pools_availability_zones" {

--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "default_nodepool_max_pods" {
 }
 
 variable "default_nodepool_availability_zones" {
-  type    = list(any)
+  type    = list(string)
   default = ["1"]
 }
 
@@ -353,13 +353,18 @@ variable "netapp_volume_path" {
 
 variable "netapp_network_features" {
   description = "Indicates which network feature to use, accepted values are Basic or Standard, it defaults to Basic if not defined."
-  type    = string
+  type        = string
   default     = "Basic"
 }
 
 variable "node_pools_availability_zone" {
   type    = string
-  default = "1"
+  default = null
+}
+
+variable "node_pools_availability_zones" {
+  type    = list(string)
+  default = ["1"]
 }
 
 variable "node_pools_proximity_placement" {
@@ -520,8 +525,8 @@ variable "subnet_names" {
   description = "Map subnet usage roles to existing subnet names"
   # Example:
   # subnet_names = {
-  #   'aks': 'my_aks_subnet', 
-  #   'misc': 'my_misc_subnet', 
+  #   'aks': 'my_aks_subnet',
+  #   'misc': 'my_misc_subnet',
   #   'netapp': 'my_netapp_subnet'
   # }
 }


### PR DESCRIPTION
# Feature:
- Allow IaC users to specify a list of availability zones for AKS worker node pools

### Summary:
- Feature introduces parity between system and worker node pool. Both pools now support a user-defined list of availability zones
- Change introduces var `node_pools_availability_zones` while preserving singular variant `node_pools_availability_zone`
- Existing variable will be honored and given priority
- Need to consider eventual deprecation of `node_pools_availability_zone`

# Tests:
Verified the following scenarios:
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|Create cluster with new variable node_pools_availability_zones as list|Fast 2020|Cluster creation with multi-zone setup was successful. Viya4 deployment on the aks cluster stabilized and applications are accessible|
|2|Create cluster with old variable node_pools_availability_zone as string|Fast 2020|Cluster creation with single availability zone was succesful. Viya4 deployment stabilized and applications are accessible|