### PR TITLE
docs: (IAC-812): Updated S2 example file For SingleStore configuration with HA storage

### DIFF
--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -104,7 +104,12 @@ create_jump_public_ip = true
 jump_vm_admin        = "jumpuser"
 jump_vm_machine_type = "Standard_B2s"
 
-# Storage for SAS Viya CAS/Compute
+# Storage for Viya Compute Services
+# Supported storage_type values
+#    "standard" - Custom managed NFS Server VM and disks
+#    "ha"     - Azure NetApp Files managed service
+
+## Standard storage type
 storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
@@ -112,6 +117,13 @@ nfs_vm_admin         = "nfsuser"
 nfs_vm_machine_type  = "Standard_D8s_v4"
 nfs_raid_disk_size   = 128
 nfs_raid_disk_type   = "Standard_LRS"
+
+## HA storage type
+# storage_type = "ha"
+# # required ONLY when storage_type = ha for Azure NetApp Files service
+# netapp_service_level    = "Premium"
+# netapp_size_in_tb       = 4
+# netapp_network_features = "Standard"    # For SingleStore configuration with ha storage 'netapp_network_features' should be set to 'Standard'
 
 # SingleStore configuration
 aks_network_plugin = "azure"


### PR DESCRIPTION
# Changes:
Deployments with SingleStore configuration and HA storage type are running into issues. The netapp_network_features has default value of `Basic`, the 1000 IP address limit that ANF has OOTB isn't enough and times out.
The solution is to use `netapp_network_features = Standard` in case of S2 configuration with HA. Updated the SingleStore example file to add comment about the same.
Note: Without S2 configuration HA works fine with `netapp_network_features = Basic`.
