### PR TITLE
feat: (IAC-600) Add support for aad rbac

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -174,6 +174,9 @@ Ubuntu 20.04 LTS is the operating system used on the Jump/NFS servers. Ubuntu cr
 | ssh_public_key | File name of public ssh key for jump and nfs VM | string | "~/.ssh/id_rsa.pub" | Required with `create_jump_vm=true` or `storage_type=standard` |
 | cluster_api_mode | Public or private IP for the cluster api | string | "public" | Valid Values: "public", "private" |
 | aks_cluster_sku_tier | Optimizes api server for cost vs availability | string | "Free" | Valid Values:  "Free", "Paid" | 
+| aks_aad | Whether to integrate this cluster with Azure Active Directory | bool | false | |
+| aks_aad_admin_group_ids | List of Azure Active Directory group ids to be granted admin access over this cluster | list of strings | null | Only relevant when `aks_aad` is true |
+| aks_aad_tenant_id | The Azure tenant id where the aforementioned admin group ids reside.  Defaults to the tenant id of the cluster | string | null | Only relevant when `aks_aad` is true |
 
 ## Node Pools
 

--- a/main.tf
+++ b/main.tf
@@ -159,6 +159,10 @@ module "aks" {
   client_id                                = var.client_id
   client_secret                            = var.client_secret
   aks_private_cluster                      = var.cluster_api_mode == "private" ? true : false
+  aks_aad                                  = var.aks_aad
+  aks_aad_tenant_id                        = var.aks_aad_tenant_id
+  aks_aad_admin_group_ids                  = var.aks_aad_admin_group_ids
+  aks_aad_azure_rbac_enabled               = var.aks_aad_azure_rbac_enabled
   depends_on                               = [module.vnet]
 }
 

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -34,6 +34,16 @@ resource "azurerm_kubernetes_cluster" "aks" {
     load_balancer_sku  = "standard"
   }
 
+  dynamic "azure_active_directory_role_based_access_control" {
+    for_each = var.aks_aad ? [1] : []
+    content {
+      managed                 = true
+      tenant_id               = var.aks_aad_tenant_id
+      admin_group_object_ids  = var.aks_aad_admin_group_ids
+      azure_rbac_enabled      = var.aks_aad_azure_rbac_enabled
+    }
+  }
+
   dynamic "linux_profile" {
     for_each = var.aks_cluster_ssh_public_key == "" ? [] : [1]
     content {

--- a/modules/azure_aks/outputs.tf
+++ b/modules/azure_aks/outputs.tf
@@ -1,9 +1,9 @@
 output "client_key" {
-  value = azurerm_kubernetes_cluster.aks.kube_config.0.client_key
+  value = var.aks_aad ? azurerm_kubernetes_cluster.aks.kube_admin_config.0.client_key : azurerm_kubernetes_cluster.aks.kube_config.0.client_key
 }
 
 output "client_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate
+  value = var.aks_aad ? azurerm_kubernetes_cluster.aks.kube_admin_config.0.client_certificate : azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate
 }
 
 output "cluster_ca_certificate" {

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -140,3 +140,27 @@ variable client_secret {
 variable "cluster_egress_type" {
   default = "loadBalancer"
 }
+
+variable "aks_aad" {
+  description = "Whether or not to integrate this cluster with Azure Active Directory"
+  type        = bool
+  default     = false
+}
+
+variable "aks_aad_tenant_id" {
+  description = "The Azure Active Directory tenant this cluster should integrate with (i.e. where aks_aad_admin_group_ids reside).  Only relevant when aks_aad is true.  Defaults to the tenant id of the cluster's subscription."
+  type        = string
+  default     = null
+}
+
+variable "aks_aad_admin_group_ids" {
+  description = "List of Azure Active Directory group ids to be granted admin access over this cluster.  Only relevant when aks_aad is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "aks_aad_azure_rbac_enabled" {
+  description = "Whether or not to enable Azure RBAC in this cluster.  Only relevant when aks_aad is true"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -610,3 +610,27 @@ variable "aks_identity" {
     error_message = "ERROR: Supported values for `aks_identity` are: uai, sp."
   }
 }
+
+variable "aks_aad" {
+  description = "Whether or not to integrate this cluster with Azure Active Directory"
+  type        = bool
+  default     = false
+}
+
+variable "aks_aad_tenant_id" {
+  description = "The Azure Active Directory tenant this cluster should integrate with (i.e. where aks_aad_admin_group_ids reside).  Only relevant when aks_aad is true.  Defaults to the tenant id of the cluster's subscription."
+  type        = string
+  default     = null
+}
+
+variable "aks_aad_admin_group_ids" {
+  description = "List of Azure Active Directory group ids to be granted admin access over this cluster.  Only relevant when aks_aad is true."
+  type        = list(string)
+  default     = null
+}
+
+variable "aks_aad_azure_rbac_enabled" {
+  description = "Whether or not to enable Azure RBAC in this cluster.  Only relevant when aks_aad is true"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Introduces an optional [azure_active_directory_role_based_access_control](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/kubernetes_cluster#azure_active_directory_role_based_access_control) block to the azure aks module.  If enabled, the cluster will be integrated with Azure AD.  RBAC permissions within the cluster can then be managed by referencing AAD users and groups.  

Does not change default behavior.

Introduces the following new variables:
- "aks_aad" - this is the primary boolean variable which will control this feature.  None of the following variables will matter if this is false.  
- "aks_aad_tenant_id"
- "aks_aad_admin_group_ids" 
- "aks_aad_azure_rbac_enabled":  disabled by default, undocumented, but here for completeness

More details in internal ticket