### PR TITLE
feat: (IAC-638): Added new optional Diagnostic Setting for AKS clusters

### DIFF
--- a/monitor.tf
+++ b/monitor.tf
@@ -76,6 +76,4 @@ resource "azurerm_monitor_diagnostic_setting" "audit" {
       }
     }
   }
-
-  tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,13 +41,13 @@ variable "location" {
   default     = "eastus"
 }
 
-variable aks_cluster_sku_tier {
+variable "aks_cluster_sku_tier" {
   description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free"
-  default = "Free"
-  type = string 
+  default     = "Free"
+  type        = string
 
   validation {
-    condition     = contains(["Free", "Paid"],  var.aks_cluster_sku_tier)
+    condition     = contains(["Free", "Paid"], var.aks_cluster_sku_tier)
     error_message = "ERROR: Valid types are \"Free\" and \"Paid\"!"
   }
 }
@@ -364,7 +364,7 @@ variable "netapp_volume_path" {
 
 variable "netapp_network_features" {
   description = "Indicates which network feature to use, accepted values are Basic or Standard, it defaults to Basic if not defined."
-  type    = string
+  type        = string
   default     = "Basic"
 }
 
@@ -439,7 +439,7 @@ variable "node_pools" {
   }
 }
 
-# Azure Monitor
+# Azure Monitor - Undocumented
 variable "create_aks_azure_monitor" {
   type        = bool
   description = "Enable Azure Log Analytics agent on AKS cluster"
@@ -486,6 +486,19 @@ variable "log_analytics_solution_promotion_code" {
   type        = string
   description = "A promotion code to be used with the solution"
   default     = ""
+}
+
+## Azure Monitor Diagonostic setting - Undocumented
+variable "resource_log_category" {
+  type        = list(string)
+  description = "List of all resource logs category types supported in Azure Monitor."
+  default     = ["kube-controller-manager", "kube-apiserver", "kube-scheduler"]
+}
+
+variable "metric_category" {
+  type        = list(string)
+  description = "List of all metric category types supported in Azure Monitor."
+  default     = ["AllMetrics"]
 }
 
 # BYO


### PR DESCRIPTION
# Changes:
New optional diagnostic setting resource block included in the aks module. Disabled by default, optionally enabled if and only if `create_aks_azure_monitor` is enabled. This diagnostic setting is connected to the aks cluster and configured to send diagnostic data to the log analytics workspace.
Changes were made following the terraform doc for this resource:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting 

# Tests:
Following scenarios were verified, see details in internal ticket.
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|In terraform.tfvars set create_aks_azure_monitor = True|Fast 2020|Diagnostic settings were enabled for the aks cluster and data was sent to log analytics workspace . Viya4 deployment on the cluster was successful all pods stabilized and applications were accessible|
|2|In terraform.tfvars set create_aks_azure_monitor = False|Fast 2020|Azure monitor was not enabled, Diagnostic settings were not present. Viya4 deployment on the cluster was successful all pods stabilized and applications were accessible|