### PR TITLE
feat: (IAC-804): Use device UUID in mount to avoid NFS issues due to restarts

### DIFF
--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -41,9 +41,6 @@ runcmd:
   #
   # Create Raid5 Array
   #
-  # NOTE: We need to sleep 5 minutes here to ensure the drives have been attached
-  #
-  # - sleep 300
   - pvcreate $(find /dev/disk/azure/scsi1/ -type l | xargs)
   - vgcreate data-vg01 $(find /dev/disk/azure/scsi1/ -type l | xargs)
   - lvcreate --type raid5 --extents 100%FREE --stripes 3 --name data-lv01 data-vg01
@@ -51,7 +48,10 @@ runcmd:
   #
   # Update /etc/fstab
   #
-  - echo "/dev/data-vg01/data-lv01       /export        ext4        defaults,nofail,x-systemd.requires=cloud-init.service,barrier=0,discard        0  2" >>/etc/fstab
+  - device=`lsblk -r | grep lvm | cut -d " " -f1 | grep -v "_"`
+  - mntDir='/export'
+  - deviceUUID=`sudo blkid /dev/mapper/$device | sed -r 's/.*UUID="([^"]*).*"/\1/g'`
+  - echo "UUID=$deviceUUID $mntDir auto defaults,acl,nofail 0 2" | sudo tee -a /etc/fstab > /dev/null
   - mount -a
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC


### PR DESCRIPTION
# Changes:
Updated the cloud-init file for nfs to address issue with raid device names being switched and mounts being missing between NFS VM restarts and or terraform (re)apply scenarios

# Tests:
Verified following scenarios, see details in internal ticket:
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|NFS VM reboot|Fast 2020|Mounts were correctly bound even after restarts. Viya4 deployment was stable and accessible|
|2|Terraform reapply (see detailed steps in ticket)|Fast 2020|Mounts were correctly bound. Viya4 deployment was stable and accessible|