### PR TITLE
feat: (IAC-638): Updated variable description and validation blocks

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -491,14 +491,30 @@ variable "log_analytics_solution_promotion_code" {
 ## Azure Monitor Diagonostic setting - Undocumented
 variable "resource_log_category" {
   type        = list(string)
-  description = "List of all resource logs category types supported in Azure Monitor."
+  description = "List of all resource logs category types supported in Azure Monitor. See https://learn.microsoft.com/en-us/azure/aks/monitor-aks-reference#resource-logs "
   default     = ["kube-controller-manager", "kube-apiserver", "kube-scheduler"]
+
+  validation {
+    condition     = length(var.resource_log_category) > 0
+    error_message = <<EOT
+    Please specify at least one resource log category. See the list of all resource logs category types
+    supported in Azure Monitor here: https://learn.microsoft.com/en-us/azure/aks/monitor-aks-reference#resource-logs
+  EOT
+  }
 }
 
 variable "metric_category" {
   type        = list(string)
-  description = "List of all metric category types supported in Azure Monitor."
+  description = "List of all metric category types supported in Azure Monitor. See https://learn.microsoft.com/en-us/azure/aks/monitor-aks-reference#metrics"
   default     = ["AllMetrics"]
+
+  validation {
+    condition     = length(var.metric_category) > 0
+    error_message = <<EOT
+    Please specify at least one metric category. See the list of all platform metrics supported in Azure Monitor
+    here: https://learn.microsoft.com/en-us/azure/aks/monitor-aks-reference#metrics
+  EOT
+  }
 }
 
 # BYO


### PR DESCRIPTION
# Changes:
Added validation for `resource_log_category` and `metric_category` variable. The variables have default so it's not mandatory to provide values but specifying empty list will throw validation errors for both the variables.

# Tests:
Specifying empty lists for `resource_log_category` and `metric_category` throws expected error