### PR TITLE
Revert "feat: (IAC-804): Use device UUID in mount to avoid NFS issues due to restarts"

### DIFF
--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -41,6 +41,9 @@ runcmd:
   #
   # Create Raid5 Array
   #
+  # NOTE: We need to sleep 5 minutes here to ensure the drives have been attached
+  #
+  # - sleep 300
   - pvcreate $(find /dev/disk/azure/scsi1/ -type l | xargs)
   - vgcreate data-vg01 $(find /dev/disk/azure/scsi1/ -type l | xargs)
   - lvcreate --type raid5 --extents 100%FREE --stripes 3 --name data-lv01 data-vg01
@@ -48,10 +51,7 @@ runcmd:
   #
   # Update /etc/fstab
   #
-  - device=`lsblk -r | grep lvm | cut -d " " -f1 | grep -v "_"`
-  - mntDir='/export'
-  - deviceUUID=`sudo blkid /dev/mapper/$device | sed -r 's/.*UUID="([^"]*).*"/\1/g'`
-  - echo "UUID=$deviceUUID $mntDir auto defaults,acl,nofail 0 2" | sudo tee -a /etc/fstab > /dev/null
+  - echo "/dev/data-vg01/data-lv01       /export        ext4        defaults,nofail,x-systemd.requires=cloud-init.service,barrier=0,discard        0  2" >>/etc/fstab
   - mount -a
   #
   # Update /etc/exports - NOTE: The CIDR provided works for the whole VPC


### PR DESCRIPTION
- (#277) was accidently merged to main branch instead of staging. 

This reverts commit 961d243c71294c26e9005c5275edfa25b5d3dc4e.