### PR TITLE
feat: (IAC-900): add K8s 1.25 support, set kubectl default to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG AZURECLI_VERSION=2.24.2
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM mcr.microsoft.com/azure-cli:$AZURECLI_VERSION
-ARG KUBECTL_VERSION=1.23.12
+ARG KUBECTL_VERSION=1.24.10
 
 WORKDIR /viya4-iac-azure
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Access to an **Azure Subscription** and an [**Identity**](./docs/user/TerraformA
 
 #### Terraform Requirements:
 - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.23.12
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.24
 - [jq](https://stedolan.github.io/jq/) - v1.6
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure) - (optional - useful as an alternative to the Azure Portal) - v2.24.2
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -163,7 +163,7 @@ Ubuntu 20.04 LTS is the operating system used on the Jump/NFS servers. Ubuntu cr
 | :--- | ---: | ---: | ---: | ---: |
 | partner_id | A GUID that is registered with Microsoft to facilitate partner resource usage attribution | string | "5d27f3ae-e49c-4dea-9aa3-b44e4750cd8c" | Defaults to SAS partner GUID. When you deploy this Terraform configuration, Microsoft can identify the installation of SAS software with the deployed Azure resources. Microsoft can then correlate the resources that are used to support the software. Microsoft collects this information to provide the best experiences with their products and to operate their business. The data is collected and governed by Microsoft's privacy policies, located at https://www.microsoft.com/trustcenter. |
 | create_static_kubeconfig | Allows the user to create a provider / service account-based kubeconfig file | bool | true | A value of `false` will default to using the cloud provider's mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig that uses a `Service Account` and `Cluster Role Binding` to provide credentials. |
-| kubernetes_version | The AKS cluster Kubernetes version | string | "1.23.12" | |
+| kubernetes_version | The AKS cluster Kubernetes version | string | "1.24" |Use of specific versions is still supported. If you need exact kubernetes version please use format `x.y.z`, where `x` is the major version, `y` is the minor version, and `z` is the patch version |
 | create_jump_vm | Create bastion host | bool | true | |
 | create_jump_public_ip | Add public IP address to the jump VM | bool | true | |
 | jump_vm_admin | Operating system Admin User for the jump VM | string | "jumpuser" | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -45,7 +45,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D4_v3"
 #v3 still has local temp storage

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -32,7 +32,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -34,7 +34,7 @@ container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 
 # AKS config
-kubernetes_version         = "1.23.12"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "Standard_D8s_v4"
 

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -67,7 +67,7 @@ variable "aks_cluster_max_pods" {
 
 variable kubernetes_version {
   description = "The AKS cluster K8s version"
-  default     = "1.23.12"
+  default     = "1.24"
 }
 variable "aks_cluster_endpoint_public_access_cidrs" {
   description = "Kubernetes cluster access IP ranges"

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,7 @@ variable "default_nodepool_vm_type" {
 }
 variable "kubernetes_version" {
   description = "The AKS cluster K8s version"
-  default     = "1.23.12"
+  default     = "1.24"
 }
 
 variable "default_nodepool_max_nodes" {


### PR DESCRIPTION
# Changes:
With SAS Viya Platform supporting K8s 1.23, 1.24, and 1.25 in 2023.03 March release cadence, updating our supported kubectl version to 1.24.10 for it to be in the +/- 1 range of the supported versions.

In this change we are also dropping the patch version requirement for the `kubernetes_version`. All the files are updated to use the format `major.minor` for `kubernetes_version`.
**Note:** Use of exact version is still supported, for exact kubernetes version you can still specify the version as `x.y.z`, where `x` is the major version, `y` is the minor version, and `z` is the patch version.

# Tests:
Verified following scenarios, see details in internal ticket:

|Scenario|Task|Provider|Cadence|kubernetes_version|Actual Kubernetes Cluster Version|Orchestration|kubectl Version|
|:----|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|Azure|fast:2020|1.24|1.24.9|Deployment Operator|1.24.10|
|2|OOTB|Azure|fast:2020|1.25|1.25.5|Deployment Operator|1.24.10|
|3|OOTB|Azure|fast:2020|1.23|1.23.15|Orchestration Tooling|1.24.10|