### PR TITLE
fix: (IAC-668) enable network acceleration correctly for NFS VM

### DIFF
--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_network_interface" "vm_nic" {
   name                          = "${var.name}-nic"
   location                      = var.azure_rg_location
   resource_group_name           = var.azure_rg_name
-  enable_accelerated_networking = length(regexall("/-nfs/", var.name)) > 0 ? true : var.enable_accelerated_networking
+  enable_accelerated_networking = length(regexall("-nfs", var.name)) > 0 ? true : var.enable_accelerated_networking
 
   ip_configuration {
     name                          = "${var.name}-ip_config"


### PR DESCRIPTION
# Changes:
Updated the regex to correctly enable network acceleration for NFS VM.

**Note:**
Enabling the network acceleration flag does not incur additional cost. The pricing of VM is still determined based on the type of VM instance you choose. For details about Network acceleration see [here](https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-overview).

The default NFS VM type is currently set to `Standard_D8s_v4` and has capability to enable network acceleration.

# Tests:
Verified network acceleration was set to true for the NFS VM only. Cluster creation and SAS Viya Platform deployment was successful. For details see internal ticket.