### PR TITLE
fix: (IAC-966) Fix validation error messages format

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -164,7 +164,7 @@ variable "aks_network_plugin" {
 
   validation {
     condition     = contains(["kubenet", "azure"], var.aks_network_plugin)
-    error_message = "Error: Currently the supported values are `kubenet` and `azure`"
+    error_message = "Error: Currently the supported values are 'kubenet' and 'azure'."
   }
 }
 
@@ -175,7 +175,7 @@ variable "aks_network_policy" {
 
   validation {
     condition     = contains(["azure", "calico"], var.aks_network_policy)
-    error_message = "Error: Currently the supported values are `calico` and `azure`"
+    error_message = "Error: Currently the supported values are 'calico' and 'azure'."
   }
 }
 
@@ -470,7 +470,7 @@ variable "netapp_network_features" {
 
   validation {
     condition     = contains(["Basic", "Standard"], var.netapp_network_features)
-    error_message = "Error: Currently the supported values are `Basic` and `Standard`"
+    error_message = "Error: Currently the supported values are 'Basic' and 'Standard'."
   }
 }
 


### PR DESCRIPTION
# Changes:
Terraform version 1.0.0 throws error on the incorrect validation error message format. 
Received error: `The validation error message must be at least one full sentence starting with an uppercase letter and ending with a period or question mark.`
This change updates the error message to add the missing period in the error message.

# Tests:
- No error is thrown on running with terraform v1.0.0