### PR TITLE
feat: (IAC-1062) Update linter secret name

### DIFF
--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: terraform-linters/setup-tflint@v3.0.0
       with:
         tflint_version: latest
-        github_token: ${{ secrets.LINTER_TEST_TOKEN }}
+        github_token: ${{ secrets.LINTER_TOKEN }}
 
     - name: Initializing TFLint
       run: TFLINT_LOG=info tflint --init -c .tflint.hcl 


### PR DESCRIPTION
# Changes:
Updated the secret name  from `LINTER_TEST_TOKEN` to `LINTER_TOKEN`.

# Tests:
Verified the new `LINTER_TOKEN` was used to run the GitHub Actions.