### PR TITLE
feat: (IAC-1020) Support for Message Broker - Azure Service Bus

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -252,6 +252,19 @@ module "netapp" {
   depends_on          = [module.vnet]
 }
 
+module "message_broker" {
+  source = "./modules/azurerm_message_broker"
+  count  = var.create_azure_message_broker ? 1 : 0
+
+  resource_group_name     = local.aks_rg.name
+  location                = var.location
+  prefix                  = var.prefix
+  message_broker_sku      = var.message_broker_sku
+  message_broker_name     = var.message_broker_name
+  message_broker_capacity = var.message_broker_capacity
+  tags                    = var.tags
+}
+
 data "external" "git_hash" {
   program = ["files/tools/iac_git_info.sh"]
 }

--- a/modules/azurerm_message_broker/main.tf
+++ b/modules/azurerm_message_broker/main.tf
@@ -1,0 +1,26 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Azure Service Bus
+# - https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview
+# - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace
+# - https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace_authorization_rule
+
+resource "azurerm_servicebus_namespace" "message_broker" {
+  name                = "${var.prefix}-message-broker"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = var.message_broker_sku
+  capacity            = var.message_broker_capacity
+
+  tags = var.tags
+}
+
+resource "azurerm_servicebus_namespace_authorization_rule" "message_broker_config" {
+  name         = var.message_broker_name
+  namespace_id = azurerm_servicebus_namespace.message_broker.id
+
+  listen = true
+  send   = true
+  manage = true
+}

--- a/modules/azurerm_message_broker/outputs.tf
+++ b/modules/azurerm_message_broker/outputs.tf
@@ -1,0 +1,10 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "message_broker_hostname" {
+  value = regex("//(.*):", azurerm_servicebus_namespace.message_broker.endpoint)
+}
+
+output "message_broker_primary_key" {
+  value = azurerm_servicebus_namespace_authorization_rule.message_broker_config.primary_key
+}

--- a/modules/azurerm_message_broker/variables.tf
+++ b/modules/azurerm_message_broker/variables.tf
@@ -1,0 +1,40 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+variable "prefix" {
+  description = "A prefix used in the name for all the Azure resources created by this script."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group in which to create the PostgreSQL Server. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "location" {
+  description = "Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "message_broker_sku" {
+  description = "Defines which tier to use. Options are Basic, Standard or Premium. SAS Viya Platform recommends using 'Premium'."
+  type        = string
+  default     = "Premium"
+}
+
+variable "message_broker_name" {
+  description = "Specifies the name of the message broker, also specified for the ServiceBus Namespace Authorization Rule resource. Changing this forces a new resource to be created."
+  type        = string
+  default     = "Arke"
+}
+
+variable "message_broker_capacity" {
+  description = "Specifies the capacity. When sku is Premium, capacity can be 1, 2, 4, 8 or 16. When sku is Basic or Standard, capacity can be 0 only."
+  type        = number
+  default     = 1
+}
+
+variable "tags" {
+  description = "Map of common tags to be placed on the Resources"
+  type        = map(any)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -144,3 +144,17 @@ output "cluster_node_pool_mode" {
 output "cluster_api_mode" {
   value = var.cluster_api_mode
 }
+
+## Message Broker - Azure Service Bus
+output "message_broker_hostname" {
+  value = element(flatten(module.message_broker[*].message_broker_hostname), 0)
+}
+
+output "message_broker_primary_key" {
+  value     = element(coalescelist(module.message_broker[*].message_broker_primary_key, [""]), 0)
+  sensitive = true
+}
+
+output "message_broker_name" {
+  value = var.message_broker_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -743,3 +743,28 @@ variable "aks_identity" {
     error_message = "ERROR: Supported values for `aks_identity` are: uai, sp."
   }
 }
+
+## Message Broker - Azure Service Bus - Experimental
+variable "create_azure_message_broker" {
+  description = "Allows user to create a fully managed enterprise message broker: Azure Service Bus"
+  type        = bool
+  default     = false
+}
+
+variable "message_broker_sku" {
+  description = "Defines which tier to use. Options are Basic, Standard or Premium. SAS Viya Platform recommends using 'Premium'."
+  type        = string
+  default     = "Premium"
+}
+
+variable "message_broker_name" {
+  description = "Specifies the name of the message broker, also specified for the ServiceBus Namespace Authorization Rule resource. Changing this forces a new resource to be created."
+  type        = string
+  default     = "Arke"
+}
+
+variable "message_broker_capacity" {
+  description = "Specifies the capacity. When sku is Premium, capacity can be 1, 2, 4, 8 or 16. When sku is Basic or Standard, capacity can be 0 only."
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
# Changes:
Support added for Message broker: `Azure service bus` to be used by SAS Viya Platform deployment.
Resources added using:
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace_authorization_rule

# Tests:
Verified following on the scenarios listed below, please see internal ticket for details.
- Verified cluster creation was successful.
- Azure Service bus was created. 
- SAS Viya Platform consumed the Azure service bus information from state file correctly. 
- Rabbitmq pods were not created.

**Note:** SAS Viya Platform services are still not ready. Almost all pods stabilized except for few services. Launcher service is failing with `[BROKER_MISSING_USERNAME]` causing other services to fail. This is expected until all the services are updated to use the new Azure Service bus instead of Rabbitmq.

|Scenario|Task|Deploy method|Cadence|
|:----|:----|:----|:----|
|1|Defaults, `create_azure_message_broker= true`, internal Postgres|ansible|fast:2020|
|2|`create_azure_message_broker= true`, external Postgres|ansible|fast:2020|
|3|`create_azure_message_broker= true`, `message_broker_name= "ritika1"`, `aks_cluster_sku_tier = "Standard"`, external Postgres|ansible|fast:2020|
