### PR TITLE
feat!: (IAC-1021) NFS version default updated to 4.1

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -315,7 +315,7 @@ When `storage_type=ha` (high availability), [Microsoft Azure NetApp Files](https
 | :--- | ---: | ---: | ---: | ---: |
 | netapp_service_level | The target performance level of the file system. Valid values include Premium, Standard, or Ultra. | string | "Premium" | |
 | netapp_size_in_tb | Provisioned size of the pool in TB. Value must be between 4 and 500 | number | 4 | |
-| netapp_protocols | The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined, it defaults to NFSv3. Changing this forces a new resource to be created and data will be lost. | list of strings | ["NFSv3"] | |
+| netapp_protocols | The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined, it defaults to NFSv4.1. Changing this forces a new resource to be created and data will be lost. | list of strings | ["NFSv4.1"] | |
 | netapp_volume_path |A unique file path for the volume. Used when creating mount targets. Changing this forces a new resource to be created. | string | "export" | |
 | netapp_network_features |Indicates which network feature to use, accepted values are `Basic` or `Standard`, it defaults to `Basic` if not defined. | string | "Basic" | This is a feature in public preview. For more information about it and how to register, please refer to [Configure network features for an Azure NetApp Files volume](https://docs.microsoft.com/en-us/azure/azure-netapp-files/configure-network-features)|
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,5 +1,12 @@
 # Troubleshooting
 
+- [Troubleshooting](#troubleshooting)
+  - [Kubernetes Version is not supported in Azure region](#kubernetes-version-is-not-supported-in-azure-region)
+  - [Failure to delete AKS Node Pool](#failure-to-delete-aks-node-pool)
+  - [Import Azure Resource into Terraform state](#import-azure-resource-into-terraform-state)
+  - [Not able to access AKS with kubectl](#not-able-to-access-aks-with-kubectl)
+  - [Azure NetApp Files creation fails](#azure-netapp-files-creation-fails)
+
 ##  Kubernetes Version is not supported in Azure region
 ```bash
 Error: creating Managed Kubernetes Cluster "viya-tst-aks" (Resource Group "viya-tst-rg"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.18.14 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"
@@ -7,7 +14,7 @@ Error: creating Managed Kubernetes Cluster "viya-tst-aks" (Resource Group "viya-
   on modules/azure_aks/main.tf line 2, in resource "azurerm_kubernetes_cluster" "aks":
    2: resource "azurerm_kubernetes_cluster" "aks" {
 ```
-**Resolution:**
+### Resolution:
 Run this Azure CLI command to get the supported Kubernetes versions in your Azure region and use value for `kubernetes_version` variable in input tfvars.
 ```bash
 az aks get-versions --location <YOUR_AZURE_LOCATION> --output table 
@@ -29,7 +36,7 @@ Error: waiting for the deletion of Node Pool "stateful" (Managed Kubernetes Clus
 Error: A resource with the ID "/subscriptions/REDACTED/resourcegroups/viya-tst-rg/providers/Microsoft.ContainerService/managedClusters/viya-tst-aks/agentPools/stateless" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_kubernetes_cluster_node_pool" for more information.
 ```
 
-**Resolution:**
+### Resolution:
 
 ```bash
 terraform import -var-file=sample-input.tfvars module.aks.azurerm_kubernetes_cluster.aks '/subscription/REDACTED/../../'
@@ -44,7 +51,7 @@ Error: authorization.RoleAssignmentsClient#Create: Failure responding to request
   18: resource "azurerm_role_assignment" "acr" {
 ```
 
-**Resolution:**
+### Resolution:
 Check values of environment variables - `ARM_* and TF_*`
 
 ## Azure NetApp Files creation fails
@@ -57,5 +64,25 @@ Error: Error creating NetApp Account "sse-vdsdp-ha1-netappaccount" (Resource Gro
   29: resource "azurerm_netapp_account" "anf" {
  ```
 
- **Resolution:**
+ ### Resolution:
  Check your Azure Subscription has been granted access to Azure NetApp Files service: [Azure Netapp Quickstart](https://docs.microsoft.com/en-us/azure/azure-netapp-files/azure-netapp-files-quickstart-set-up-account-create-volumes?tabs=azure-portal#before-you-begin)
+
+
+## Azure NetApp NFSv3 volume file lock issue
+In event of SAS Viya Platform deployment shutdown on an AKS cluster with Azure NetApp NFSv3 volume, the file locks persist and `sas-consul-server` cannot access raft.db until the file locks are broken. 
+
+### Resolution:
+There are two options to avoid this issue:
+
+1. Break the file locks from Azure Portal. For details see [Troubleshoot file locks on an Azure NetApp Files volume](https://learn.microsoft.com/en-us/azure/azure-netapp-files/troubleshoot-file-locks).
+
+2. Use Azure NetApp NFS volume version 4.1. This can be done by adding the variable `netapp_protocols` to your terraform.tfvars.
+
+   **Note:** Changing this on existing cluster will result in data loss.
+   
+   Example:
+   ```bash
+   # Storage HA
+   storage_type = "ha"
+   netapp_protocols = ["NFSv4.1"]
+   ``` 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -6,6 +6,7 @@
   - [Import Azure Resource into Terraform state](#import-azure-resource-into-terraform-state)
   - [Not able to access AKS with kubectl](#not-able-to-access-aks-with-kubectl)
   - [Azure NetApp Files creation fails](#azure-netapp-files-creation-fails)
+  - [Azure NetApp NFSv3 volume file lock issue](#azure-netapp-nfsv3-volume-file-lock-issue)
 
 ##  Kubernetes Version is not supported in Azure region
 ```bash

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -77,7 +77,7 @@ There are two options to avoid this issue:
 
 1. Break the file locks from Azure Portal. For details see [Troubleshoot file locks on an Azure NetApp Files volume](https://learn.microsoft.com/en-us/azure/azure-netapp-files/troubleshoot-file-locks).
 
-2. Use Azure NetApp NFS volume version 4.1. You can update the `viya4-iac-azure` to latest version to use NFSv4.1 by default. If you are using v7.2.0 or below of viya4-iac-azure then you add the variable `netapp_protocols` to your terraform.tfvars to switch to NFSv4.1.
+2. Use Azure NetApp NFS volume version 4.1. Update to the latest version of `sassoftware/viya4-iac-azure` to use NFSv4.1 by default. If you are using sassoftware/viya4-iac-azure's release v7.2.0 or before, then add the variable `netapp_protocols` to your terraform.tfvars to switch to NFSv4.1.
 
    **Note:** Changing this on existing cluster will result in data loss.
    

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -77,7 +77,7 @@ There are two options to avoid this issue:
 
 1. Break the file locks from Azure Portal. For details see [Troubleshoot file locks on an Azure NetApp Files volume](https://learn.microsoft.com/en-us/azure/azure-netapp-files/troubleshoot-file-locks).
 
-2. Use Azure NetApp NFS volume version 4.1. This can be done by adding the variable `netapp_protocols` to your terraform.tfvars.
+2. Use Azure NetApp NFS volume version 4.1. You can update the `viya4-iac-azure` to latest version to use NFSv4.1 by default. If you are using v7.2.0 or below of viya4-iac-azure then you add the variable `netapp_protocols` to your terraform.tfvars to switch to NFSv4.1.
 
    **Note:** Changing this on existing cluster will result in data loss.
    

--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -58,10 +58,13 @@ runcmd:
   #
   - if [ "${aks_cidr_block}" != "${misc_cidr_block}" ]
   - then
-  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
-  -   echo "/export         ${misc_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  -   echo "/         ${aks_cidr_block}(ro,fsid=0)" >> /etc/exports
+  -   echo "/         ${misc_cidr_block}(ro,fsid=0)" >> /etc/exports
+  -   echo "/export   ${aks_cidr_block}(rw,no_root_squash,async,insecure,crossmnt,no_subtree_check)" >> /etc/exports
+  -   echo "/export   ${misc_cidr_block}(rw,no_root_squash,async,insecure,crossmnt,no_subtree_check)" >> /etc/exports
   - else
-  -   echo "/export         ${aks_cidr_block}(rw,no_root_squash,async,insecure,fsid=0,crossmnt,no_subtree_check)" >> /etc/exports
+  -   echo "/         ${aks_cidr_block}(ro,fsid=0)" >> /etc/exports
+  -   echo "/export   ${aks_cidr_block}(rw,no_root_squash,async,insecure,crossmnt,no_subtree_check)" >> /etc/exports
   - fi
   #
   # Restart nfs-server service

--- a/modules/azurerm_netapp/variables.tf
+++ b/modules/azurerm_netapp/variables.tf
@@ -55,9 +55,9 @@ variable "volume_path" {
 }
 
 variable "protocols" {
-  description = "The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined it will default to NFSv3. Changing this forces a new resource to be created and data will be lost."
+  description = "The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined it will default to NFSv4.1. Changing this forces a new resource to be created and data will be lost."
   type        = list(string)
-  default     = ["NFSv3"]
+  default     = ["NFSv4.1"]
 }
 
 variable "allowed_clients" {

--- a/variables.tf
+++ b/variables.tf
@@ -451,9 +451,9 @@ variable "netapp_size_in_tb" {
 }
 
 variable "netapp_protocols" {
-  description = "The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined it will default to NFSv3. Changing this forces a new resource to be created and data will be lost."
+  description = "The target volume protocol expressed as a list. Supported single value include CIFS, NFSv3, or NFSv4.1. If argument is not defined it will default to NFSv4.1. Changing this forces a new resource to be created and data will be lost."
   type        = list(string)
-  default     = ["NFSv3"]
+  default     = ["NFSv4.1"]
 }
 
 variable "netapp_volume_path" {

--- a/vms.tf
+++ b/vms.tf
@@ -12,6 +12,8 @@ locals {
     : var.storage_type == "ha" ? module.netapp[0].netapp_path : "/export"
   )
 
+  protocol_version = var.storage_type == "ha" && startswith(var.netapp_protocols[0], "NFS") ? split("v", var.netapp_protocols[0])[1] : "3"
+
   jump_cloudconfig = var.create_jump_vm ? templatefile("${path.module}/files/cloud-init/jump/cloud-config", {
     mounts = (var.storage_type == "none"
       ? "[]"
@@ -19,7 +21,7 @@ locals {
         ["${local.rwx_filestore_endpoint}:${local.rwx_filestore_path}",
           var.jump_rwx_filestore_path,
           "nfs",
-          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=1048576,wsize=1048576,vers=3,tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
+          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=1048576,wsize=1048576,vers=${local.protocol_version},tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
           "0",
           "0"
       ])

--- a/vms.tf
+++ b/vms.tf
@@ -11,7 +11,7 @@ locals {
 
   rwx_filestore_path = (var.storage_type == "none"
     ? ""
-    : var.storage_type == "ha" ? module.netapp[0].netapp_path : local.protocol_version == "3" ? "/export" : "/"
+    : var.storage_type == "ha" ? module.netapp[0].netapp_path : "/export"
   )
 
   jump_cloudconfig = var.create_jump_vm ? templatefile("${path.module}/files/cloud-init/jump/cloud-config", {
@@ -21,7 +21,7 @@ locals {
         ["${local.rwx_filestore_endpoint}:${local.rwx_filestore_path}",
           var.jump_rwx_filestore_path,
           "nfs",
-          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=1048576,wsize=1048576,nfsvers=${local.protocol_version},tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
+          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=1048576,wsize=1048576,vers=${local.protocol_version},tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
           "0",
           "0"
       ])


### PR DESCRIPTION
## Changes:
NFS version default is now updated to v4.1 for both `storage_type = "standard"` and `storage_type = "ha"`.
Previously the `vers` value was hardcoded to `3`, which caused NFS mounts to fail when `netapp_protocols` is set to NFSv4.1. 
This PR reads the value set and replaces the `vers` parameter. Also added note in Troubleshooting.md for file lock issue seen with NFSv3.

### Breaking Change:
This is a breaking change. Upgrading an existing infrastructure that has SAS Viya Platform deployed on it will result in data loss. The changes in this PR destroy and create the NFS VM or Azure NetApp Volume when upgraded, which will result in data loss affecting your existing SAS Viya Platform deployment. 

To avoid SAS Viya Platform deployment data loss perform backup before upgrading, see details in [SAS Documentation](https://go.documentation.sas.com/doc/en/itopscdc/default/calbr/p0cw7yuvwc83znn1igjc16zah2se.htm).

## Tests:
Verified following scenarios, see details in internal ticket:

|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|Defaults, `storage_type = "standard"`|Fast 2020|NFSv4.1 was used, Jump server was able to mount correctly, SAS Viya Platform deployment stabilized and was accessible|
|1|Defaults, `storage_type = "ha"` and `netapp_protocols = ["NFSv3"]`|Fast 2020|Cluster is created with Azure NetApp using NFS volume v3. Viya4 deployment stabilized and was accessible|
|2|Defaults, `storage_type = "ha"`|Fast 2020|Cluster is created with Azure NetApp using NFS volume v4.1. Viya4 deployment stabilized and was accessible|