### PR TITLE
fix: (IAC-1090) Fixed jumpvm cloud-init causing Viya deployment failure

### DIFF
--- a/files/cloud-init/jump/cloud-config
+++ b/files/cloud-init/jump/cloud-config
@@ -43,12 +43,15 @@ runcmd:
       # mount the nfs
       #
   -   while [ `df -h | grep "${rwx_filestore_endpoint}:${rwx_filestore_path}" | wc -l` -eq 0 ]; do sleep 5 && mount -a ; done
-      #
-      # Change permissions and owner
-      #
-  -   mkdir -p ${jump_rwx_filestore_path}/pvs
-  -   $(chmod -fR 777 ${jump_rwx_filestore_path} ; echo)
-  -   $(chown -R nobody:nogroup ${jump_rwx_filestore_path} ; echo)
+  -   if ! [ -d "${jump_rwx_filestore_path}/pvs" ]
+  -   then
+        #
+        # Change permissions and owner
+        #
+  -     mkdir -p ${jump_rwx_filestore_path}/pvs
+  -     $(chmod -fR 777 ${jump_rwx_filestore_path} ; echo)
+  -     $(chown -R nobody:nogroup ${jump_rwx_filestore_path} ; echo)
+  -   fi
   - fi
   #
   # Update user for Docker, user=${vm_admin}

--- a/outputs.tf
+++ b/outputs.tf
@@ -147,14 +147,14 @@ output "cluster_api_mode" {
 
 ## Message Broker - Azure Service Bus
 output "message_broker_hostname" {
-  value = element(flatten(module.message_broker[*].message_broker_hostname), 0)
+  value = var.create_azure_message_broker ? element(flatten(module.message_broker[*].message_broker_hostname), 0) : null
 }
 
 output "message_broker_primary_key" {
-  value     = element(coalescelist(module.message_broker[*].message_broker_primary_key, [""]), 0)
+  value     = var.create_azure_message_broker ? element(coalescelist(module.message_broker[*].message_broker_primary_key, [""]), 0) : null
   sensitive = true
 }
 
 output "message_broker_name" {
-  value = var.message_broker_name
+  value = var.create_azure_message_broker ? var.message_broker_name : null
 }


### PR DESCRIPTION
## Changes:
When a new jump server vm is created, it sets file ownership and permissions for the mounted NFS location which allows Viya services to initialize successfully. Importantly, the file system settings should only be applied once and not repeatedly in the event that the jump vm is destroyed and recreated in the same cluster. This change checks if the `${jump_rwx_filestore_path}/pvs` folder already exists and skips creating the folder and recursively setting ownerships and permissions if it does. If the jump vm is being created for the first time when the pvs folder is absent, creating the folder and setting permissions and ownership will occur an initial time and not thereafter.

This issue originated from AWS, but is applicable for all cloud providers. See the original fix in [AWS PR](https://github.com/sassoftware/viya4-iac-aws/pull/212).

Also, minor update to `outputs.tf` file: updated a missing condition.

## Tests:
Verified the following steps, see details in internal ticket.

#### Steps:
 - Created cluster using IaC Azure
 - Verify infrastructure created successfully
 - Deploy Viya4 using DaC
 - Verify Viya deployment is stabilized
 - Stop Viya. Follow SAS documentation: [Stop a SAS Viya Platform Deployment](https://go.documentation.sas.com/doc/en/itopscdc/v_040/itopssrv/n0pwhguy22yhe0n1d7pgi63mf6pb.htm#p05jsfcz54bsejn1x1r34f0zrag6)
 - Verify all pods are terminated
 - Replace jump server vm using terraform replace command (Alternative to destroy and create), verifyed that the existing jump vm is destroyed and a new one is created.
 - Start Viya following the SAS documentation: [Start a SAS Viya Platform Deployment](https://go.documentation.sas.com/doc/en/itopscdc/v_040/itopssrv/n0pwhguy22yhe0n1d7pgi63mf6pb.htm#p05jsfcz54bsejn1x1r34f0zrag6)
 - Check deployment/pods status verify all Viya pods, services and applications stabilize and are accessible.