### PR TITLE
feat: (IAC-1100) Update terraform azurerm provider version to support flexible postgreSQL version 15

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,11 +8,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.54.0"
+      version = "3.63.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.38.0"
+      version = "2.39.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.63.0"
+      version = "3.64.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
# Changes:
The current terraform `azurerm` provider version `3.54.0` doesn't support Flexible PostgreSQL Server v15. Terraform provider added support for the same in `v3.59.0.`

This PR updates the provider `azurerm` version to latest which `v3.64.0` as of now. Also updated `azuread` version for consistency with the current available version.

# Tests:
Verified following scenarios, see internal ticket for details
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|Default, external PostgreSQL version 15|Fast 2020|Flexible Postgres Server was created with version 15. Viya4 deployment stabilized and was accessible|
|2|Default, internal PostgreSQL, Standard SKU-tier, Azure NetApp default `NFSv4.1`|Fast 2020|Cluster was created successfully. Baseline tasks were successful, Viya4 deployment stabilized and was accessible|