### PR TITLE
docs: (IAC-1138) jump server cloud-init file permissions & ownership

### DIFF
--- a/files/cloud-init/jump/cloud-config
+++ b/files/cloud-init/jump/cloud-config
@@ -43,10 +43,13 @@ runcmd:
       # mount the nfs
       #
   -   while [ `df -h | grep "${rwx_filestore_endpoint}:${rwx_filestore_path}" | wc -l` -eq 0 ]; do sleep 5 && mount -a ; done
+      # Create pvs folder and adjust permissions and ownership only if the folder doesn't exist
+      # On subsequent jump server creation if the mounted NFS already contains a "pvs" directory
+      # then do not overwrite permissions and ownership set by SAS Viya
   -   if ! [ -d "${jump_rwx_filestore_path}/pvs" ]
   -   then
         #
-        # Change permissions and owner
+        # Change permissions and ownership
         #
   -     mkdir -p ${jump_rwx_filestore_path}/pvs
   -     $(chmod -fR 777 ${jump_rwx_filestore_path} ; echo)


### PR DESCRIPTION
## Changes:
The necessary changes required for preventing Jump VM cloud-init from overwriting existing file permissions/ownership were added in PR #327. This PR adds comments to provide additional context around the same.