### PR TITLE
docs: (IAC-1157) updated incorrect storage_mb default value in CONFIG-VARS

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -352,7 +352,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | sku_name| The SKU Name for the PostgreSQL Flexible Server | string | "GP_Standard_D16s_v3" | The name pattern is the SKU, followed by the tier + family + cores (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3).|
-| storage_mb | The max storage allowed for the PostgreSQL Flexible Server | number | 51200 | Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432. |
+| storage_mb | The max storage allowed for the PostgreSQL Flexible Server | number | 65536 | Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432. |
 | backup_retention_days | Backup retention days for the PostgreSQL Flexible server | number | 7 | Supported values are between 7 and 35 days. |
 | geo_redundant_backup_enabled | Enable Geo-redundant or not for server backup | bool | false | Not supported for the basic tier. |
 | administrator_login | The Administrator Login for the PostgreSQL Flexible Server. Changing this forces a new resource to be created. | string | "pgadmin" | The admin login name cannot be azure_superuser, azure_pg_admin, admin, administrator, root, guest, or public. It cannot start with pg_. See: [Microsoft Quickstart Server Database](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/quickstart-create-server-portal) |


### PR DESCRIPTION
## Changes:
Updated the incorrect storage_mb default value for Flexible PostgreSQL server in CONFIG-VARS