### PR TITLE
fix: (IAC-1072) Enabling North-South traffic

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,10 @@ output "aks_cluster_password" {
   sensitive = true
 }
 
+output "aks_pod_cidr" {
+  value = var.aks_pod_cidr
+}
+
 # postgres
 
 output "postgres_servers" {


### PR DESCRIPTION
## Changes:
Starting Kubernetes version `1.25` the north-south traffic in Azure stopped working. There were no changes to `azure-ip-masq-agent` or `coredns`. On investigating further found out that changes were made to Azure's standard Loadbalancer. See the following note in [AKS public standard load balancer documentation](https://learn.microsoft.com/en-us/azure/aks/load-balancer-standard#restrict-inbound-traffic-to-specific-ip-ranges)

![image](https://github.com/sassoftware/viya4-iac-azure/assets/94649368/06a78714-506e-480d-bb6e-5483291f3d3b)

To enable the North-South traffic again for AKS clusters, adding the `aks_pod_cidr` to terraform output for viya4-deployment to consume the changes.

## Tests:
Verified `aks_pod_cidr` was included in terraform.tfstate file