### PR TITLE
chore: (IAC-1238) Resolve TFLint issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -281,13 +281,13 @@ resource "kubernetes_config_map" "sas_iac_buildinfo" {
   }
 
   data = {
-    git-hash    = lookup(data.external.git_hash.result, "git-hash")
+    git-hash    = data.external.git_hash.result["git-hash"]
     iac-tooling = var.iac_tooling
     terraform   = <<EOT
-version: ${lookup(data.external.iac_tooling_version.result, "terraform_version")}
-revision: ${lookup(data.external.iac_tooling_version.result, "terraform_revision")}
-provider-selections: ${lookup(data.external.iac_tooling_version.result, "provider_selections")}
-outdated: ${lookup(data.external.iac_tooling_version.result, "terraform_outdated")}
+version: ${data.external.iac_tooling_version.result["terraform_version"]}
+revision: ${data.external.iac_tooling_version.result["terraform_revision"]}
+provider-selections: ${data.external.iac_tooling_version.result["provider_selections"]}
+outdated: ${data.external.iac_tooling_version.result["terraform_outdated"]}
 EOT
   }
 


### PR DESCRIPTION
### Changes
Update the code to resolve `terraform_deprecated_lookup` linting issues 

doc: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_deprecated_lookup.md

### Tests

Created infrastructure and ensured the `sas-iac-buildinfo` was present

```
$ kubectl get cm -n kube-system sas-iac-buildinfo -o yaml
apiVersion: v1
data:
  git-hash: 6471f1f2fc6edf1701a2d93fc2dc41d9073199d9
  iac-tooling: terraform
  terraform: |
    version: "1.4.5"
    revision: null
    provider-selections: {"registry.terraform.io/hashicorp/azuread":"2.39.0","registry.terraform.io/hashicorp/azurerm":"3.64.0","registry.terraform.io/hashicorp/cloudinit":"2.3.2","registry.terraform.io/hashicorp/external":"2.3.1","registry.terraform.io/hashicorp/kubernetes":"2.20.0","registry.terraform.io/hashicorp/local":"2.4.0","registry.terraform.io/hashicorp/null":"3.2.1","registry.terraform.io/hashicorp/tls":"4.0.4"}
    outdated: true
immutable: false
kind: ConfigMap
metadata:
  creationTimestamp: "2023-11-22T18:37:55Z"
  name: sas-iac-buildinfo
  namespace: kube-system
  resourceVersion: "1237"
  uid: b7c6670a-71cb-4755-a8a0-b56072bc638a
```