### PR TITLE
feat: (IAC-276) Support Azure Application Gateway with Azure WAF

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -390,22 +390,7 @@ postgres_servers = {
 
 ## Azure Application Gateway with Azure Web Application Firewall (WAF)
 
-Azure Web Application Firewall (WAF) on Azure Application Gateway provides centralized protection of your web applications from common exploits and vulnerabilities. To enable Azure Application Gateway with WAF you need to provide all the required variables as discussed below:
-
-The variable has the following format:
-```
-create_app_gateway = true
-app_gateway_config = {
-  backend_trusted_root_certificate = "<path-to-root-cert>" ## .cer format required
-  ssl_certificate = [{
-    data     = "<path-to-listener-cert>"  ## .pfx format required
-    password = "<your-password>"
-  }]
-  backend_address_pool_fqdn = [<ingress-loadBalancer-fqdn>]
-}
-
-waf_policy = "<path-to-WAF-policy-file>"  ## .json format required
-```
+Azure Web Application Firewall (WAF) on Azure Application Gateway provides centralized protection from common exploits and vulnerabilities. Please see the [sample input file](../examples/sample-input-app-gateway.tfvars) for Application Gateway creation example.
 
 | Name | Description | Type | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- |
@@ -414,25 +399,27 @@ waf_policy = "<path-to-WAF-policy-file>"  ## .json format required
 | waf_policy | A JSON file with all the WAF_Policy rules | map | null | The WAF policy has few required components see the details below. |
 
 The `app_gateway_config` variable can contain none, some, or all of the parameters listed below:
+For the details of all the parameters that can be specified see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway
+
 | Name | Description | Type | Required | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | sku | The Name of the SKU to use for this Application Gateway. | string | false | "Standard_v2" | If WAF policy is enabled the default is `"WAF_v2"` |
 | port | The port which should be used for this Application Gateway. | string | false | "443" |  |
 | protocol | The Protocol which should be used. | string | false  | "Https" | Possible values are Http and Https.|
-| backend_host_name | FQDN for the Gateway | string | False | null |Set this variable when using custom DNS. Not setting this will use Azure Public DNS to set the FQDN for Application Gateway Public IP.|
-| backend_trusted_root_certificate | The Trusted Root Certificate to use. | string | True | null  | |
-| ssl_certificate |The associated SSL Certificate which should be used for this HTTP Listener. | map | True | null |List of data, password or key_vault_secret_id|
-| identity_ids | Specifies a list of User Assigned Managed Identity IDs to be assigned to this Application Gateway. | list | False | null | Required when specifying key_vault_secret_id |
-| backend_address_pool_fqdn | A list of FQDN's which should be part of the Backend Address Pool.  | list | True | null |Add the FQDN of your Ingress-Nginx. Note: You can specify the anticipated FQDN of your ingress without affecting the Gateway creation. This can also be manually updated later in Portal|
-| probe | Custom health probes to be created for the Application Gateway. | map | False | "default-probe" ||
+| backend_host_name | Hostname for the Application Gateway | string | false | null |Set this variable when using custom DNS. Not setting this will use Azure Public DNS to set the FQDN for Application Gateway Public IP.|
+| backend_trusted_root_certificate | The Trusted Root Certificate to use. | list(map(string)) | true | null  | List of map containing: name, data, or key_vault_secret_id. `key_vault_secret_id` is required if `data` is not set. |
+| ssl_certificate |The associated SSL Certificate which should be used for this HTTP Listener. | list(map(string)) | true | null | List of map containing: name, data, password or key_vault_secret_id. `key_vault_secret_id` is required if `data` is not set.|
+| identity_ids | Specifies a list of User Assigned Managed Identity IDs to be assigned to this Application Gateway. | list | false | null | Required when specifying key_vault_secret_id |
+| backend_address_pool_fqdn | A list of FQDN's which should be part of the Backend Address Pool. | list | true | null | Add the FQDN of your Ingress-Nginx. Note: You can specify the anticipated FQDN of your ingress without affecting the Gateway creation. This can also be manually updated later in Portal|
+| probe | Custom health probes to be created for the Application Gateway. | map | false | "default-probe" ||
 
 The `waf_policy` variable is json file which can contain none, some, or all of the parameters listed below:
 For the details of all the parameters that can be specified see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy
 | Name | Description | Type | Required | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| custom_rules | Specifies one or more custom_rules blocks  | list(map) | False | | |
-| policy_settings | Specifies A policy_settings block | map | False |  |  |
-| managed_rules | A managed_rules blocks | list(map) | True  | | |
+| custom_rules | Specifies one or more custom_rules blocks  | list(map) | false | | |
+| policy_settings | Specifies A policy_settings block | map | false |  |  |
+| managed_rules | A managed_rules blocks | list(map) | true  | | |
 
 Example WAF Policy:
 ```

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -419,7 +419,7 @@ For the details of all the parameters that can be specified see: https://registr
 | Name | Description | Type | Required | Default | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | custom_rules | Specifies one or more custom_rules blocks  | list(map) | false | | |
-| policy_settings | Specifies A policy_settings block | map | false |  |  |
+| policy_settings | Specifies a policy_settings block | map | false |  |  |
 | managed_rules | A managed_rules blocks | list(map) | true  | | |
 
 Example WAF Policy:

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -21,6 +21,7 @@ Supported configuration variables are listed in the tables below.  All variables
     - [Azure NetApp Files (only when `storage_type=ha`)](#azure-netapp-files-only-when-storage_typeha)
   - [Azure Container Registry (ACR)](#azure-container-registry-acr)
   - [Postgres Servers](#postgres-servers)
+  - [Azure Application Gateway with Azure Web Application Firewall (WAF)](#azure-application-gateway-with-azure-web-application-firewall-waf)
 
 Terraform input variables can be set in the following ways:
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -397,7 +397,6 @@ Azure Web Application Firewall (WAF) on Azure Application Gateway provides centr
 | :--- | :--- | :--- | :--- | :--- |
 | create_app_gateway | Creates Azure Application Gateway | bool | false | |
 | app_gateway_config | Map of Application Gateway configuration objects | map | null | All the variables that can be defined in the `app_gateway_config` are described in table below. |
-| waf_policy | A JSON file with all the WAF_Policy rules | map | null | The WAF policy has few required components see the details below. |
 
 The `app_gateway_config` variable can contain none, some, or all of the parameters listed below:
 For the details of all the parameters that can be specified see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway
@@ -407,6 +406,7 @@ For the details of all the parameters that can be specified see: https://registr
 | sku | The Name of the SKU to use for this Application Gateway. | string | false | "Standard_v2" | If WAF policy is enabled the default is `"WAF_v2"` |
 | port | The port which should be used for this Application Gateway. | string | false | "443" |  |
 | protocol | The Protocol which should be used. | string | false  | "Https" | Possible values are Http and Https.|
+| waf_policy | A JSON file with all the WAF_Policy rules | map | null | The WAF policy has few required components see the details below. |
 | backend_host_name | Hostname for the Application Gateway | string | false | null |Set this variable when using custom DNS. Not setting this will use Azure Public DNS to set the FQDN for Application Gateway Public IP.|
 | backend_trusted_root_certificate | The Trusted Root Certificate to use. | list(map(string)) | true | null  | List of map containing: name, data, or key_vault_secret_id. `key_vault_secret_id` is required if `data` is not set. |
 | ssl_certificate |The associated SSL Certificate which should be used for this HTTP Listener. | list(map(string)) | true | null | List of map containing: name, data, password or key_vault_secret_id. `key_vault_secret_id` is required if `data` is not set.|
@@ -423,7 +423,7 @@ For the details of all the parameters that can be specified see: https://registr
 | managed_rules | A managed_rules blocks | list(map) | true  | | |
 
 Example WAF Policy:
-```
+```json
 {
     "custom_rules": [
         {

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -387,3 +387,114 @@ postgres_servers = {
   }
 }
 ```
+
+## Azure Application Gateway with Azure Web Application Firewall (WAF)
+
+Azure Web Application Firewall (WAF) on Azure Application Gateway provides centralized protection of your web applications from common exploits and vulnerabilities. To enable Azure Application Gateway with WAF you need to provide all the required variables as discussed below:
+
+The variable has the following format:
+```
+create_app_gateway = true
+app_gateway_config = {
+  backend_trusted_root_certificate = "<path-to-root-cert>" ## .cer format required
+  ssl_certificate = [{
+    data     = "<path-to-listener-cert>"  ## .pfx format required
+    password = "<your-password>"
+  }]
+  backend_address_pool_fqdn = [<ingress-loadBalancer-fqdn>]
+}
+
+waf_policy = "<path-to-WAF-policy-file>"  ## .json format required
+```
+
+| Name | Description | Type | Default | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| create_app_gateway | Creates Azure Application Gateway | bool | false | |
+| app_gateway_config | Map of Application Gateway configuration objects | map | null | All the variables that can be defined in the `app_gateway_config` are described in table below. |
+| waf_policy | A JSON file with all the WAF_Policy rules | map | null | The WAF policy has few required components see the details below. |
+
+The `app_gateway_config` variable can contain none, some, or all of the parameters listed below:
+| Name | Description | Type | Required | Default | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| sku | The Name of the SKU to use for this Application Gateway. | string | false | "Standard_v2" | If WAF policy is enabled the default is `"WAF_v2"` |
+| port | The port which should be used for this Application Gateway. | string | false | "443" |  |
+| protocol | The Protocol which should be used. | string | false  | "Https" | Possible values are Http and Https.|
+| backend_host_name | FQDN for the Gateway | string | False | null |Set this variable when using custom DNS. Not setting this will use Azure Public DNS to set the FQDN for Application Gateway Public IP.|
+| backend_trusted_root_certificate | The Trusted Root Certificate to use. | string | True | null  | |
+| ssl_certificate |The associated SSL Certificate which should be used for this HTTP Listener. | map | True | null |List of data, password or key_vault_secret_id|
+| identity_ids | Specifies a list of User Assigned Managed Identity IDs to be assigned to this Application Gateway. | list | False | null | Required when specifying key_vault_secret_id |
+| backend_address_pool_fqdn | A list of FQDN's which should be part of the Backend Address Pool.  | list | True | null |Add the FQDN of your Ingress-Nginx. Note: You can specify the anticipated FQDN of your ingress without affecting the Gateway creation. This can also be manually updated later in Portal|
+| probe | Custom health probes to be created for the Application Gateway. | map | False | "default-probe" ||
+
+The `waf_policy` variable is json file which can contain none, some, or all of the parameters listed below:
+For the details of all the parameters that can be specified see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy
+| Name | Description | Type | Required | Default | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| custom_rules | Specifies one or more custom_rules blocks  | list(map) | False | | |
+| policy_settings | Specifies A policy_settings block | map | False |  |  |
+| managed_rules | A managed_rules blocks | list(map) | True  | | |
+
+Example WAF Policy:
+```
+{
+    "custom_rules": [
+        {
+            "name": "SASIPWhiteList",
+            "priority": 1,
+            "rule_type": "MatchRule",
+            "action": "Block",
+            "match_conditions": [
+                {
+                    "match_variables": [
+                        {
+                            "variable_name": "RemoteAddr"
+                        }
+                    ],
+                    "operator": "IPMatch",
+                    "negation_condition": true,
+                    "match_values": [
+                        "<your-IP-to-be-whitelisted>"
+                    ],
+                    "transforms": []
+                }
+            ],
+            "enabled": true
+        }
+    ],
+    "policy_settings": {
+        "request_body_check": true,
+        "max_request_body_size_in_kb": 2000,
+        "file_upload_limit_in_mb": 4000,
+        "enabled": true,
+        "mode": "Prevention",
+        "request_body_inspect_limit_in_kb": 2000
+    },
+    "managed_rules": {
+        "exclusion": [
+            {
+                "match_variable": "RequestHeaderNames",
+                "selector": "x-company-secret-header",
+                "selector_match_operator": "Equals"
+            }
+        ],
+        "managed_rule_set": [
+            {
+                "type": "OWASP",
+                "version": "3.2",
+                "rule_group_override": [
+                    {
+                        "rule_group_name": "REQUEST-920-PROTOCOL-ENFORCEMENT",
+                        "rule": [
+                            {
+                                "id": "920300",
+                                "enabled": true,
+                                "action": "Log"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+```

--- a/examples/sample-input-app-gateway.tfvars
+++ b/examples/sample-input-app-gateway.tfvars
@@ -32,6 +32,7 @@ postgres_servers = {
 create_app_gateway = true
 
 app_gateway_config = {
+  waf_policy = "<path-to-WAF-policy-json-file>"   ## Required to configure WAF with Application Gateway
   backend_host_name = "<your Application Gateway host name>"  ## leave empty to use Azure public DNS assigned host name
   backend_trusted_root_certificate = [{
     name = "<rootcert-name>"
@@ -48,8 +49,6 @@ app_gateway_config = {
   ## Example identity_ids value: `/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityValue`
   backend_address_pool_fqdn = ["<your-ingress-nginx-loadBalancer-hostname>"]  ## Required to setup the backend pool. This list only accepts FQDN.
 }
-
-waf_policy = "<path-to-WAF-policy-json-file>"   ## Required to configure WAF with Application Gateway
 
 # AKS config
 kubernetes_version         = "1.26"

--- a/examples/sample-input-app-gateway.tfvars
+++ b/examples/sample-input-app-gateway.tfvars
@@ -1,0 +1,120 @@
+# !NOTE! - These are only a subset of CONFIG-VARS.md provided as examples.
+# Customize this file to add any variables from 'CONFIG-VARS.md' whose default values you
+# want to change.
+
+# ****************  REQUIRED VARIABLES  ****************
+# These required variables' values MUST be provided by the User
+prefix   = "<prefix-value>" # this is a prefix that you assign for the resources to be created
+location = "<azure-location-value>" # e.g., "eastus2"
+# ****************  REQUIRED VARIABLES  ****************
+
+# !NOTE! - Without specifying your CIDR block access rules, ingress traffic
+#          to your cluster will be blocked by default. In a SCIM environment,
+#          the AzureActiveDirectory service tag must be granted access to port
+#          443/HTTPS for the ingress IP address. 
+
+# **************  RECOMMENDED  VARIABLES  ***************
+default_public_access_cidrs = [] # e.g., ["123.45.6.89/32"]
+ssh_public_key              = "~/.ssh/id_rsa.pub"
+# **************  RECOMMENDED  VARIABLES  ***************
+
+# Tags can be specified matching your tagging strategy.
+tags = {} # for example: { "owner|email" = "<you>@<domain>.<com>", "key1" = "value1", "key2" = "value2" }
+
+# Postgres config - By having this entry a database server is created. If you do not
+#                   need an external database server remove the 'postgres_servers'
+#                   block below.
+postgres_servers = {
+  default = {},
+}
+
+## Azure Application Gateway with Azure Web Application Firewall (WAF)
+create_app_gateway = true
+
+app_gateway_config = {
+  backend_host_name = "<your Application Gateway host name>"  ## leave empty to use Azure public DNS assigned host name
+  backend_trusted_root_certificate = [{
+    name = "<rootcert-name>"
+    data = "<path-to-rootcert>"  ## Required if key_vault_secret_id not set
+    key_vault_secret_id = "<key-vault-scret-id>" ## Required if data not set
+  }]
+  ssl_certificate = [{
+    name = "<listener-cert-name>"
+    data = "<path-to-listener-cert>"  ## Required if key_vault_secret_id not set
+    password = "<password>"  ## Required when data is set
+    key_vault_secret_id = "<key-vault-scret-id>" ## Required if data not set
+  }]
+  identity_ids              = ["<identity-id-with-access-to-key-vault>"] ## Required if key_vault_secret_id is set above. 
+  ## Example identity_ids value: `/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/userAssignedIdentityValue`
+  backend_address_pool_fqdn = ["<your-ingress-nginx-loadBalancer-hostname>"]  ## Required to setup the backend pool. This list only accepts FQDN.
+}
+
+waf_policy = "<path-to-WAF-policy-json-file>"   ## Required to configure WAF with Application Gateway
+
+# AKS config
+kubernetes_version         = "1.26"
+default_nodepool_min_nodes = 2
+default_nodepool_vm_type   = "Standard_D8s_v4"
+
+# AKS Node Pools config
+node_pools = {
+  cas = {
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "cas"
+    }
+  },
+  compute = {
+    "machine_type" = "Standard_E16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class"        = "compute"
+      "launcher.sas.com/prepullImage" = "sas-programming-environment"
+    }
+  },
+  stateless = {
+    "machine_type" = "Standard_D16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 2
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "stateless"
+    }
+  },
+  stateful = {
+    "machine_type" = "Standard_D8s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "stateful"
+    }
+  }
+}
+
+# Jump Server
+create_jump_public_ip = true
+jump_vm_admin        = "jumpuser"
+jump_vm_machine_type = "Standard_B2s"
+
+# Storage for SAS Viya CAS/Compute
+storage_type = "standard"
+# required ONLY when storage_type is "standard" to create NFS Server VM
+create_nfs_public_ip = false
+nfs_vm_admin         = "nfsuser"
+nfs_vm_machine_type  = "Standard_D8s_v4"
+nfs_raid_disk_size   = 128
+nfs_raid_disk_type   = "Standard_LRS"

--- a/iam.tf
+++ b/iam.tf
@@ -12,4 +12,5 @@ resource "azurerm_user_assigned_identity" "uai" {
   name                = "${var.prefix}-aks-identity"
   resource_group_name = local.aks_rg.name
   location            = var.location
+  tags                = var.tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -41,7 +41,7 @@ locals {
 
   # App Gateway
   app_gateway_config = merge(var.app_gateway_defaults, var.app_gateway_config)
-  waf_policy_config  = var.waf_policy != null ? jsondecode(file(var.waf_policy)) : null
+  waf_policy_config  = local.app_gateway_config.waf_policy != null ? jsondecode(file(local.app_gateway_config.waf_policy)) : null
   waf_policy_enabled = local.waf_policy_config != null ? length(local.waf_policy_config) != 0 ? true : false : false
 
   # Container Registry

--- a/locals.tf
+++ b/locals.tf
@@ -16,7 +16,7 @@ locals {
   cluster_endpoint_public_access_cidrs = var.cluster_api_mode == "private" ? [] : (var.cluster_endpoint_public_access_cidrs == null ? local.default_public_access_cidrs : var.cluster_endpoint_public_access_cidrs)
   postgres_public_access_cidrs         = var.postgres_public_access_cidrs == null ? local.default_public_access_cidrs : var.postgres_public_access_cidrs
 
-  subnets = { for k, v in var.subnets : k => v if !(k == "netapp" && var.storage_type == "standard") }
+  subnets = { for k, v in var.subnets : k => v if !(k == "netapp" && var.storage_type == "standard") && !(k == "gateway" && !var.create_app_gateway) }
 
   # Kubernetes
   kubeconfig_filename = "${var.prefix}-aks-kubeconfig.conf"
@@ -38,6 +38,11 @@ locals {
       "internal" : false
     }
   } : {}
+
+  # App Gateway
+  app_gateway_config = merge(var.app_gateway_defaults, var.app_gateway_config)
+  waf_policy_config  = var.waf_policy != null ? jsondecode(file(var.waf_policy)) : null
+  waf_policy_enabled = local.waf_policy_config != null ? length(local.waf_policy_config) != 0 ? true : false : false
 
   # Container Registry
   container_registry_sku = title(var.container_registry_sku)

--- a/main.tf
+++ b/main.tf
@@ -266,6 +266,30 @@ module "message_broker" {
   tags                    = var.tags
 }
 
+module "app_gateway" {
+  source = "./modules/azurerm_app_gateway"
+  count  = var.create_app_gateway ? 1 : 0
+
+  prefix                           = var.prefix
+  resource_group_name              = local.aks_rg.name
+  location                         = var.location
+  sku                              = local.app_gateway_config.sku
+  port                             = local.app_gateway_config.port
+  protocol                         = local.app_gateway_config.protocol
+  waf_policy_enabled               = local.waf_policy_enabled
+  waf_policy_config                = local.waf_policy_config
+  backend_host_name                = local.app_gateway_config.backend_host_name
+  backend_trusted_root_certificate = local.app_gateway_config.backend_trusted_root_certificate
+  ssl_certificate                  = local.app_gateway_config.ssl_certificate
+  identity_ids                     = local.app_gateway_config.identity_ids
+  backend_address_pool_fqdn        = local.app_gateway_config.backend_address_pool_fqdn
+  probe                            = local.app_gateway_config.probe
+  subnet_id                        = module.vnet.subnets["gateway"].id
+  tags                             = var.tags
+
+  depends_on = [module.vnet]
+}
+
 data "external" "git_hash" {
   program = ["files/tools/iac_git_info.sh"]
 }

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -3,22 +3,22 @@
 
 # Reference: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster
 resource "azurerm_kubernetes_cluster" "aks" {
-  name                               = var.aks_cluster_name
-  location                           = var.aks_cluster_location
-  resource_group_name                = var.aks_cluster_rg
-  dns_prefix                         = var.aks_private_cluster == false || var.aks_cluster_private_dns_zone_id == "" ? var.aks_cluster_dns_prefix : null
-  dns_prefix_private_cluster         = var.aks_private_cluster && var.aks_cluster_private_dns_zone_id != "" ? var.aks_cluster_dns_prefix : null
+  name                       = var.aks_cluster_name
+  location                   = var.aks_cluster_location
+  resource_group_name        = var.aks_cluster_rg
+  dns_prefix                 = var.aks_private_cluster == false || var.aks_cluster_private_dns_zone_id == "" ? var.aks_cluster_dns_prefix : null
+  dns_prefix_private_cluster = var.aks_private_cluster && var.aks_cluster_private_dns_zone_id != "" ? var.aks_cluster_dns_prefix : null
 
-  sku_tier                           = var.aks_cluster_sku_tier
-  role_based_access_control_enabled  = true
-  http_application_routing_enabled   = false
-  
+  sku_tier                          = var.aks_cluster_sku_tier
+  role_based_access_control_enabled = true
+  http_application_routing_enabled  = false
+
   # https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
   # az aks get-versions --location eastus -o table
-  kubernetes_version                 = var.kubernetes_version
-  api_server_authorized_ip_ranges    = var.aks_cluster_endpoint_public_access_cidrs
-  private_cluster_enabled            = var.aks_private_cluster
-  private_dns_zone_id                = var.aks_private_cluster && var.aks_cluster_private_dns_zone_id != "" ? var.aks_cluster_private_dns_zone_id : (var.aks_private_cluster ? "System" : null)
+  kubernetes_version              = var.kubernetes_version
+  api_server_authorized_ip_ranges = var.aks_cluster_endpoint_public_access_cidrs
+  private_cluster_enabled         = var.aks_private_cluster
+  private_dns_zone_id             = var.aks_private_cluster && var.aks_cluster_private_dns_zone_id != "" ? var.aks_cluster_private_dns_zone_id : (var.aks_private_cluster ? "System" : null)
 
   network_profile {
     network_plugin = var.aks_network_plugin
@@ -45,7 +45,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     content {
       admin_username = var.aks_cluster_node_admin
       ssh_key {
-         key_data = var.aks_cluster_ssh_public_key
+        key_data = var.aks_cluster_ssh_public_key
       }
     }
   }
@@ -80,7 +80,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dynamic "identity" {
     for_each = var.aks_uai_id == null ? [] : [1]
     content {
-      type = "UserAssigned"
+      type         = "UserAssigned"
       identity_ids = [var.aks_uai_id]
     }
   }
@@ -108,8 +108,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
 }
 
- data "azurerm_public_ip" "cluster_public_ip" {
-  count               = var.cluster_egress_type == "loadBalancer" ? 1 : 0
+data "azurerm_public_ip" "cluster_public_ip" {
+  count = var.cluster_egress_type == "loadBalancer" ? 1 : 0
 
   # effective_outbound_ips is a set of strings, that needs to be converted to a list type
   name                = split("/", tolist(azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips)[0])[8]

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -146,7 +146,7 @@ variable "aks_dns_service_ip" {
   type        = string
   default     = "10.0.0.10"
   validation {
-    condition     = var.aks_dns_service_ip != null ? can(regex("^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",var.aks_dns_service_ip)) : false
+    condition     = var.aks_dns_service_ip != null ? can(regex("^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", var.aks_dns_service_ip)) : false
     error_message = "ERROR: aks_dns_service_ip - value must not be null and must be a valid IP address."
   }
 
@@ -225,6 +225,6 @@ variable "cluster_egress_type" {
 }
 
 variable "aks_cluster_private_dns_zone_id" {
-  type = string
+  type    = string
   default = ""
 }

--- a/modules/azurerm_app_gateway/main.tf
+++ b/modules/azurerm_app_gateway/main.tf
@@ -1,0 +1,216 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+## https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway
+## https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy
+
+locals {
+  backend_address_pool_name      = "${var.prefix}-backend-pool"
+  frontend_port_name             = "${var.prefix}-frontend-port"
+  frontend_ip_configuration_name = "${var.prefix}-frontend-ip"
+  http_setting_name              = "${var.prefix}-backend-setting"
+  listener_name                  = "${var.prefix}-listener"
+  request_routing_rule_name      = "${var.prefix}-routing-rule"
+}
+
+resource "azurerm_public_ip" "gateway_ip" {
+  name                = "${var.prefix}-gateway-public_ip"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = var.backend_host_name == null ? "${var.prefix}-appgateway" : null
+  tags                = var.tags
+}
+
+resource "azurerm_web_application_firewall_policy" "waf_policy" {
+  count = var.waf_policy_enabled ? 1 : 0
+
+  name                = "${var.prefix}-waf-policy"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = var.tags
+
+  dynamic "custom_rules" {
+    for_each = var.waf_policy_config.custom_rules
+    content {
+      name      = custom_rules.value.name
+      priority  = custom_rules.value.priority
+      rule_type = custom_rules.value.rule_type
+      action    = custom_rules.value.action
+      dynamic "match_conditions" {
+        for_each = custom_rules.value.match_conditions
+        content {
+          operator           = match_conditions.value.operator
+          negation_condition = match_conditions.value.negation_condition
+          match_values       = match_conditions.value.match_values
+          dynamic "match_variables" {
+            for_each = match_conditions.value.match_variables
+            content {
+              variable_name = match_variables.value.variable_name
+            }
+          }
+        }
+      }
+    }
+  }
+
+  dynamic "policy_settings" {
+    for_each = var.waf_policy_config.policy_settings != null ? [var.waf_policy_config.policy_settings] : []
+    content {
+      enabled                     = policy_settings.value.enabled
+      mode                        = policy_settings.value.mode
+      request_body_check          = policy_settings.value.request_body_check
+      file_upload_limit_in_mb     = policy_settings.value.file_upload_limit_in_mb
+      max_request_body_size_in_kb = policy_settings.value.max_request_body_size_in_kb
+    }
+  }
+
+  managed_rules {
+    dynamic "exclusion" {
+      for_each = var.waf_policy_config.managed_rules.exclusion
+      content {
+        match_variable          = exclusion.value.match_variable
+        selector                = exclusion.value.selector
+        selector_match_operator = exclusion.value.selector_match_operator
+        dynamic "excluded_rule_set" {
+          for_each = exclusion.value.excluded_rule_set
+          content {
+            type    = excluded_rule_set.value.type
+            version = excluded_rule_set.value.version
+            dynamic "rule_group" {
+              for_each = excluded_rule_set.value.rule_group
+              content {
+                rule_group_name = rule_group.value.rule_group_name
+                excluded_rules  = rule_group.value.excluded_rules
+              }
+            }
+          }
+        }
+      }
+    }
+
+    dynamic "managed_rule_set" {
+      for_each = var.waf_policy_config.managed_rules.managed_rule_set
+      content {
+        type    = managed_rule_set.value.type
+        version = managed_rule_set.value.version
+        dynamic "rule_group_override" {
+          for_each = managed_rule_set.value.rule_group_override
+          content {
+            rule_group_name = rule_group_override.value.rule_group_name
+            dynamic "rule" {
+              for_each = rule_group_override.value.rule
+              content {
+                id      = rule.value.id
+                enabled = rule.value.enabled
+                action  = rule.value.action
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "azurerm_application_gateway" "appgateway" {
+  name                              = "${var.prefix}-appgateway"
+  resource_group_name               = var.resource_group_name
+  location                          = var.location
+  firewall_policy_id                = var.waf_policy_enabled ? azurerm_web_application_firewall_policy.waf_policy[0].id : null
+  force_firewall_policy_association = var.waf_policy_enabled ? true : false
+
+  sku {
+    name     = var.waf_policy_enabled ? "WAF_v2" : var.sku
+    tier     = var.waf_policy_enabled ? "WAF_v2" : "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "${var.prefix}-gateway-ip-configuration"
+    subnet_id = var.subnet_id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = var.port
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.gateway_ip.id
+  }
+
+  backend_address_pool {
+    name  = local.backend_address_pool_name
+    fqdns = var.backend_address_pool_fqdn != null ? length(var.backend_address_pool_fqdn) != 0 ? var.backend_address_pool_fqdn : null : null
+  }
+
+  dynamic "trusted_root_certificate" {
+    for_each = var.backend_trusted_root_certificate == null ? [] : [1]
+
+    content {
+      name = "root-cert"
+      data = filebase64(var.backend_trusted_root_certificate)
+    }
+  }
+
+  dynamic "ssl_certificate" {
+    for_each = var.ssl_certificate == null ? [] : var.ssl_certificate
+
+    content {
+      name                = "ListenerCert"
+      data                = ssl_certificate.value.data != null ? filebase64(ssl_certificate.value.data) : null
+      password            = ssl_certificate.value.password
+      key_vault_secret_id = ssl_certificate.value.data != null ? null : ssl_certificate.value.key_vault_secret_id
+    }
+  }
+
+  backend_http_settings {
+    name                           = local.http_setting_name
+    cookie_based_affinity          = "Disabled"
+    port                           = var.port
+    protocol                       = var.protocol
+    request_timeout                = 60
+    probe_name                     = var.probe != null ? "default-probe" : null
+    host_name                      = var.backend_host_name == null ? azurerm_public_ip.gateway_ip.fqdn : var.backend_host_name
+    trusted_root_certificate_names = var.backend_trusted_root_certificate == null ? null : ["root-cert"]
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = var.protocol
+    ssl_certificate_name           = var.ssl_certificate == null ? null : "ListenerCert"
+  }
+
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+    priority                   = 1
+  }
+
+  dynamic "probe" {
+    for_each = var.probe != null ? var.probe : []
+
+    content {
+      name                                      = probe.value.name
+      interval                                  = 60
+      protocol                                  = var.protocol
+      path                                      = probe.value.path
+      timeout                                   = 30
+      unhealthy_threshold                       = 3
+      pick_host_name_from_backend_http_settings = true
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [azurerm_web_application_firewall_policy.waf_policy]
+}

--- a/modules/azurerm_app_gateway/outputs.tf
+++ b/modules/azurerm_app_gateway/outputs.tf
@@ -1,0 +1,6 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "gateway_frontend_ip" {
+  value = azurerm_public_ip.gateway_ip.ip_address
+}

--- a/modules/azurerm_app_gateway/variables.tf
+++ b/modules/azurerm_app_gateway/variables.tf
@@ -49,7 +49,7 @@ variable "backend_host_name" {
 
 variable "backend_trusted_root_certificate" {
   description = "The Trusted Root Certificate to use."
-  type        = string
+  type        = any
   default     = null
 }
 

--- a/modules/azurerm_app_gateway/variables.tf
+++ b/modules/azurerm_app_gateway/variables.tf
@@ -1,0 +1,86 @@
+# Copyright © 2020-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+variable "prefix" {
+  description = "A prefix used in the name for all the Azure resources created by this script."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group in which to create the Azure Application Gateway. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "location" {
+  description = "Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "The ID of the Subnet which the Application Gateway should be connected to."
+  type        = string
+}
+
+variable "tags" {
+  description = "Map of common tags to be placed on the Resources"
+  type        = map(any)
+}
+
+variable "sku" {
+  description = "The Name of the SKU to use for this Application Gateway."
+  type        = string
+}
+
+variable "port" {
+  description = "The port which should be used for this Application Gateway."
+  type        = string
+}
+
+variable "protocol" {
+  description = "The Protocol which should be used. Possible values are Http and Https."
+  type        = string
+}
+
+variable "backend_host_name" {
+  description = "Host header to be sent to the backend servers."
+  type        = string
+  default     = null
+}
+
+variable "backend_trusted_root_certificate" {
+  description = "The Trusted Root Certificate to use."
+  type        = string
+  default     = null
+}
+
+variable "ssl_certificate" {
+  description = "The associated SSL Certificate which should be used for this HTTP Listener."
+  type        = any
+  default     = null
+}
+
+variable "backend_address_pool_fqdn" {
+  description = "A list of FQDN's which should be part of the Backend Address Pool."
+  type        = list(any)
+}
+
+variable "identity_ids" {
+  description = "Specifies a list of User Assigned Managed Identity IDs to be assigned to this Application Gateway."
+  type        = list(any)
+  default     = null
+}
+
+variable "waf_policy_enabled" {
+  description = "Is the Web Application Firewall enabled?"
+  type        = bool
+}
+
+variable "waf_policy_config" {
+  description = "Azure Web Application Firewall Policy instance configuration."
+  type        = any
+}
+
+variable "probe" {
+  description = "Health probes to be created for the Application Gateway."
+  type        = any
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -162,3 +162,12 @@ output "message_broker_primary_key" {
 output "message_broker_name" {
   value = var.create_azure_message_broker ? var.message_broker_name : null
 }
+
+## Application Gateway
+output "app_gateway_enabled" {
+  value = var.create_app_gateway ? var.create_app_gateway : null
+}
+
+output "app_gateway_frontend_ip" {
+  value = var.create_app_gateway ? module.app_gateway[0].gateway_frontend_ip : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -718,6 +718,13 @@ variable "subnets" {
         }
       }
     }
+    gateway = {
+      "prefixes" : ["192.168.4.0/24"],
+      "service_endpoints" : [],
+      "private_endpoint_network_policies_enabled" : true,
+      "private_link_service_network_policies_enabled" : false,
+      "service_delegations" : {}
+    }
   }
 }
 
@@ -756,8 +763,8 @@ variable "aks_identity" {
 
 variable "aks_cluster_private_dns_zone_id" {
   description = "Specify private DNS zone resource ID for AKS private cluster to use."
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 ## Message Broker - Azure Service Bus - Experimental
@@ -783,4 +790,47 @@ variable "message_broker_capacity" {
   description = "Specifies the capacity. When sku is Premium, capacity can be 1, 2, 4, 8 or 16. When sku is Basic or Standard, capacity can be 0 only."
   type        = number
   default     = 1
+}
+
+## Azure Application Gateway
+variable "create_app_gateway" {
+  description = "Allows user to create Azure Application Gateway"
+  type        = bool
+  default     = false
+}
+
+# Defaults
+variable "app_gateway_defaults" {
+  description = "Default config for Azure Application Gateway"
+  type        = any
+  default = {
+    sku                              = "Standard_v2"
+    port                             = "443"
+    protocol                         = "Https"
+    backend_host_name                = null
+    backend_trusted_root_certificate = null
+    ssl_certificate = [{
+      data                = null
+      password            = null
+      key_vault_secret_id = null
+    }]
+    identity_ids              = []
+    backend_address_pool_fqdn = []
+    probe = [{
+      name = "default-probe"
+      path = "/SASLogon/apiMeta"
+    }]
+  }
+}
+
+variable "app_gateway_config" {
+  description = "Map of Application Gateway configuration objects"
+  type        = any
+  default     = {}
+}
+
+variable "waf_policy" {
+  description = "A JSON file with all the WAF_Policy rules"
+  type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -810,8 +810,9 @@ variable "app_gateway_defaults" {
     backend_host_name                = null
     backend_trusted_root_certificate = null
     ssl_certificate                  = null
-    identity_ids                     = []
-    backend_address_pool_fqdn        = []
+    identity_ids                     = null
+    backend_address_pool_fqdn        = null
+    waf_policy                       = null
     probe = [{
       name = "default-probe"
       path = "/SASLogon/apiMeta"
@@ -823,10 +824,4 @@ variable "app_gateway_config" {
   description = "Map of Application Gateway configuration objects"
   type        = any
   default     = {}
-}
-
-variable "waf_policy" {
-  description = "A JSON file with all the WAF_Policy rules"
-  type        = string
-  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -809,13 +809,9 @@ variable "app_gateway_defaults" {
     protocol                         = "Https"
     backend_host_name                = null
     backend_trusted_root_certificate = null
-    ssl_certificate = [{
-      data                = null
-      password            = null
-      key_vault_secret_id = null
-    }]
-    identity_ids              = []
-    backend_address_pool_fqdn = []
+    ssl_certificate                  = null
+    identity_ids                     = []
+    backend_address_pool_fqdn        = []
     probe = [{
       name = "default-probe"
       path = "/SASLogon/apiMeta"


### PR DESCRIPTION
## Changes:
New feature to support Azure Application Gateway with Azure WAF. New terraform azurerm resources were added to support this feature following the information from: 
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy

**Note:** There are related changes in the `viya4-deployment` repo to support the changes made here in IAC-Azure.
Also note, the work in SAS Viya products is still in progress so there might be more changes coming in this feature but this change should help the initial testing effort.

## Tests:
Verified following scenarios, see internal ticket for details.

|Scenario|Task|Provider|Cadence|kubernetes_version|Deploy method|
|:----|:----|:----|:----|:----|:----|
|1|OOTB, `create_app_gateway = true`, Used Azure public DNS, provided both root and ssl certs as data |Azure|fast:2020|1.26|ansible, DO: false|
|2|OOTB, `create_app_gateway = true`, Used Azure public DNS, provided both root as data and ssl certs via key vault and set identity_ids|Azure|fast:2020|1.26|ansible, DO: true|
|3|OOTB,  `create_app_gateway = true`, Used SAS DNS, provided both root and ssl certs as data|Azure|fast:2020|1.26|ansible, DO: true|