### PR TITLE
Add ZebClient in Direct mode deployment as storage type for viya4.

### DIFF
--- a/examples/sample-input-zebclient-direct.tfvars
+++ b/examples/sample-input-zebclient-direct.tfvars
@@ -1,0 +1,104 @@
+# !NOTE! - These are only a subset of CONFIG-VARS.md provided as examples.
+# Customize this file to add any variables from 'CONFIG-VARS.md' whose default
+# values you want to change.
+
+# ****************  REQUIRED VARIABLES  ****************
+# These required variables' values MUST be provided by the User
+prefix   = "<prefix-value>"         # this is a prefix that you assign for the resources to be created
+location = "<azure-location-value>" # e.g., "eastus2"
+# ****************  REQUIRED VARIABLES  ****************
+
+# !NOTE! - Without specifying your CIDR block access rules, ingress traffic
+#          to your cluster will be blocked by default.
+
+# **************  RECOMMENDED  VARIABLES  ***************
+default_public_access_cidrs = [] # e.g., ["123.45.6.89/32"]
+ssh_public_key              = "~/.ssh/id_rsa.pub"
+# **************  RECOMMENDED  VARIABLES  ***************
+
+# Tags can be specified matching your tagging strategy.
+tags = {} # for example: { "owner|email" = "<you>@<domain>.<com>", "key1" = "value1", "key2" = "value2" }
+
+# Postgres config - By having this entry a database server is created. If you do not
+#                   need an external database server remove the 'postgres_servers'
+#                   block below.
+postgres_servers = {
+  default = {},
+}
+
+# Azure Container Registry config
+create_container_registry        = false
+container_registry_sku           = "Standard"
+container_registry_admin_enabled = false
+
+# AKS config
+kubernetes_version         = "1.26"
+default_nodepool_min_nodes = 2
+default_nodepool_vm_type   = "Standard_D8s_v4"
+
+# AKS Node Pools config
+node_pools = {
+  cas = {
+    "machine_type" = "Standard_L32s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=cas:NoSchedule", "zebware.com/zebclient-agent=enabled:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class"           = "cas"
+      "zebware.com/zebclient-agent-size" = "medium"
+    }
+  },
+  compute = {
+    "machine_type" = "Standard_L8s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=compute:NoSchedule", "zebware.com/zebclient-agent=enabled:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class"           = "compute"
+      "launcher.sas.com/prepullImage"    = "sas-programming-environment"
+      "zebware.com/zebclient-agent-size" = "medium"
+    }
+  },
+  stateless = {
+    "machine_type" = "Standard_L16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 1
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule", "zebware.com/zebclient-agent=enabled:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class"           = "stateless"
+      "zebware.com/zebclient-agent-size" = "medium"
+    }
+  },
+  stateful = {
+    "machine_type" = "Standard_L16s_v3"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 3
+    "max_pods"     = 110
+    "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule", "zebware.com/zebclient-agent=enabled:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class"           = "stateful"
+      "zebware.com/zebclient-agent-size" = "medium"
+    }
+  }
+}
+
+# Jump Box
+create_jump_public_ip = true
+jump_vm_admin         = "jumpuser"
+
+# Storage for Viya Compute Services
+# Supported storage_type values
+#    "standard"  - Custom managed NFS Server VM and disks
+#    "ha"        - Azure NetApp Files managed service
+#    "zebclient" - Zebware storage
+storage_type = "zebclient"
+# required ONLY when storage_type = zebclient
+zebclient_license_key = "A_VALID_LICENSE_KEY"
+zebclient_deploy_mode = "direct"

--- a/outputs.tf
+++ b/outputs.tf
@@ -110,14 +110,14 @@ output "provider" {
 }
 
 output "rwx_filestore_endpoint" {
-  value = (var.storage_type == "none"
+  value = (var.storage_type == "none" || var.storage_type == "zebclient"
     ? null
     : var.storage_type == "ha" ? module.netapp[0].netapp_endpoint : module.nfs[0].private_ip_address
   )
 }
 
 output "rwx_filestore_path" {
-  value = (var.storage_type == "none"
+  value = (var.storage_type == "none" || var.storage_type == "zebclient"
     ? null
     : var.storage_type == "ha" ? module.netapp[0].netapp_path : "/export"
   )
@@ -161,4 +161,27 @@ output "message_broker_primary_key" {
 
 output "message_broker_name" {
   value = var.create_azure_message_broker ? var.message_broker_name : null
+}
+
+## Zebclient
+output "zebclient_management_node_public_ip" {
+  value = (var.storage_type == "zebclient"
+    ? module.zebclient_direct[0].mgmt_node_public_ip
+    : null
+  )
+}
+
+output "zebclient_management_ssh_user" {
+  value = (var.storage_type == "zebclient"
+    ? module.zebclient_direct[0].ssh_username
+    : null
+  )
+}
+
+output "zebclient_management_ssh_private_key" {
+  value = (var.storage_type == "zebclient"
+    ? module.zebclient_direct[0].ssh_private_key
+    : null
+  )
+  sensitive = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -356,8 +356,8 @@ variable "storage_type" {
   default     = "standard"
   # NOTE: storage_type=none is for internal use only
   validation {
-    condition     = contains(["standard", "ha", "none"], lower(var.storage_type))
-    error_message = "ERROR: Supported values for `storage_type` are - standard, ha, none."
+    condition     = contains(["standard", "ha", "zebclient", "none"], lower(var.storage_type))
+    error_message = "ERROR: Supported values for `storage_type` are - standard, ha, zebclient, none."
   }
 }
 
@@ -756,8 +756,8 @@ variable "aks_identity" {
 
 variable "aks_cluster_private_dns_zone_id" {
   description = "Specify private DNS zone resource ID for AKS private cluster to use."
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 ## Message Broker - Azure Service Bus - Experimental
@@ -783,4 +783,117 @@ variable "message_broker_capacity" {
   description = "Specifies the capacity. When sku is Premium, capacity can be 1, 2, 4, 8 or 16. When sku is Basic or Standard, capacity can be 0 only."
   type        = number
   default     = 1
+}
+
+
+## Zebclient Storage
+variable "zebclient_license_key" {
+  description = "ZebClient license key. If you don't have one you can contact Zebware.com to get one."
+  type        = string
+}
+
+variable "zebclient_deploy_mode" {
+  description = "Specifies the deployment mode for ZebClient storage option."
+  type        = string
+  default     = "direct"
+}
+
+variable "zebclient_k_value" {
+  description = "ZebClient K part of the K+M value."
+  type        = number
+  default     = 1
+}
+
+variable "zebclient_m_value" {
+  description = "ZebClient M part of the K+M value."
+  type        = number
+  default     = 0
+}
+
+variable "zebclient_agent_pod_sizes" {
+  description = "ZebClient agent pods settings"
+  type        = list(any)
+  default = [
+    {
+      node_selector_label   = "zebware.com/zebclient-agent-size"
+      node_selector_value   = "small"
+      zc_limit              = "2GiB"
+      zc_fs_cache_size      = "128MiB"
+      zc_fs_max_uploads     = 4
+      zc_fs_buffer_size     = "256MiB"
+      zc_fs_max_compactions = 2
+      pod_lim_cpu           = "0.5"
+      pod_lim_mem           = "2.2Gi"
+      pod_req_cpu           = "0.5"
+      pod_req_mem           = "2.2Gi"
+    },
+    {
+      node_selector_label   = "zebware.com/zebclient-agent-size"
+      node_selector_value   = "medium"
+      zc_limit              = "5GiB"
+      zc_fs_cache_size      = "1600MiB"
+      zc_fs_max_uploads     = 8
+      zc_fs_buffer_size     = "512MiB"
+      zc_fs_max_compactions = 4
+      pod_lim_cpu           = "2"
+      pod_lim_mem           = "5.2Gi"
+      pod_req_cpu           = "2"
+      pod_req_mem           = "5.2Gi"
+    },
+    {
+      node_selector_label   = "zebware.com/zebclient-agent-size"
+      node_selector_value   = "large"
+      zc_limit              = "8GiB"
+      zc_fs_cache_size      = "7600MiB"
+      zc_fs_max_uploads     = 16
+      zc_fs_buffer_size     = "1024MiB"
+      zc_fs_max_compactions = 8
+      pod_lim_cpu           = "4"
+      pod_lim_mem           = "8.2Gi"
+      pod_req_cpu           = "4"
+      pod_req_mem           = "8.2Gi"
+    }
+  ]
+}
+
+variable "zebclient_keydb_vm_size" {
+  description = "Keydb instance size"
+  type        = string
+  default     = "Standard_D4s_v3"
+}
+
+variable "zebclient_mgmt_vm_size" {
+  description = "Management node instance type. Used for SSH to Zebware Cluster."
+  type        = string
+  default     = "Standard_B2s"
+}
+
+variable "zebclient_tolerations" {
+  description = "Tolerations for zebclient controller and agent pods."
+  type        = list(any)
+  default = [
+    {
+      key      = "workload.sas.com/class",
+      operator = "Exists",
+      effect   = "NoSchedule"
+    },
+    {
+      key      = "zebware.com/zebclient-agent",
+      operator = "Exists",
+      effect   = "NoSchedule"
+    }
+  ]
+}
+
+### ZebClient monitoring with NetData Ref: https://www.netdata.cloud
+variable "zebclient_netdata_claim_token" {
+  description = "(Optional) In case of NetData enabled, set NetData's claim token to get ZebClient metrics pushed."
+  type        = string
+  default     = ""
+}
+
+variable "zebclient_netdata_claim_room" {
+  description = "(Optional) In case of NetData enabled, set NetData's claim token to get ZebClient metrics pushed."
+  type        = string
+  default     = ""
 }

--- a/vms.tf
+++ b/vms.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 locals {
-  rwx_filestore_endpoint = (var.storage_type == "none"
+  rwx_filestore_endpoint = (var.storage_type == "none" || var.storage_type == "zebclient"
     ? ""
     : var.storage_type == "ha" ? module.netapp[0].netapp_endpoint : module.nfs[0].private_ip_address
   )


### PR DESCRIPTION
This pr adds ZebClient as storage type


Usage example:

```bash
terraform apply  \
  --var-file examples/sample-input-zebclient-direct.tfvars \
  --var subscription_id=xxx-xxx-xxx-xxx-xxxx \
  --var tenant_id=xxx-xxx-xxx-xxx-xxx \
  --var zebclient_license_key=xxx-xxx-xxx-xxx-xxx-xxx \
  --var prefix=viya4-zcdirect \
  --var location=swedencentral \
  --var default_public_access_cidrs='["xxx.xxx.xxx.xxx/32"]'
```