### PR TITLE
fix: (IAC-1321) updates to create NSG in network rg

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,7 +53,7 @@ locals {
   )
 
   nsg         = var.nsg_name == null ? azurerm_network_security_group.nsg[0] : data.azurerm_network_security_group.nsg[0]
-  nsg_rg_name = var.nsg_name == null ? local.aks_rg.name : local.network_rg.name
+  nsg_rg_name = local.network_rg.name
 
   # Use BYO UAI if given, else create a UAI
   aks_uai_id = (var.aks_identity == "uai"

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_network_security_group" "nsg" {
   count               = var.nsg_name == null ? 1 : 0
   name                = "${var.prefix}-nsg"
   location            = var.location
-  resource_group_name = local.aks_rg.name
+  resource_group_name = local.network_rg.name
   tags                = var.tags
 }
 


### PR DESCRIPTION
## Changes:
All network related resources should get created into a vnet resource group if supplied by user. VNET gets created correctly in network resource group if `vnet_resource_group_name` is provided however, NSG creation was not following the same pattern. This PR corrects that behavior to follow the same logic.

If `vnet_resource_group_name` is provided without `nsg_name`, IAC will create NSG for you in the provided vnet resource group else NSG will created in the AKS resource group like before.
- fixes #328 

## Tests:
Verified following scenarios, see test details in internal ticket:
| Scenario | Provider | Task          | kubectl version | order  | cadence        |notes|
|----------|----------|-----------------------------|-----------------|--------|------------|------------|
| 1        | Azure      | Defaults  | 1.27.9          | ****** | fast:2020 | NSG is created in aks rg |
| 2        | Azure      | Defaults, `vnet_resource_group_name = "rp-vnet-rg-t02"`| 1.27.9          | ****** | fast:2020 | NSG is created in provided vnet rg |