### PR TITLE
feat: (IAC-1386) EncryptAtHost changes for NIST

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,8 @@ module "aks" {
   aks_cluster_max_pods                     = var.default_nodepool_max_pods
   aks_cluster_os_disk_size                 = var.default_nodepool_os_disk_size
   aks_cluster_node_vm_size                 = var.default_nodepool_vm_type
-  aks_cluster_enable_host_encryption       = var.enable_default_nodepool_host_encryption
+  aks_cluster_enable_host_encryption       = var.aks_cluster_enable_host_encryption
+  aks_node_disk_encryption_set_id          = var.aks_node_disk_encryption_set_id
   aks_cluster_node_admin                   = var.node_vm_admin
   aks_cluster_ssh_public_key               = try(file(var.ssh_public_key), "")
   aks_cluster_private_dns_zone_id          = var.aks_cluster_private_dns_zone_id
@@ -208,7 +209,7 @@ module "node_pools" {
   zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zones != null) ? var.node_pools_availability_zones : [var.node_pools_availability_zone]
   proximity_placement_group_id = element(coalescelist(azurerm_proximity_placement_group.proximity[*].id, [""]), 0)
   orchestrator_version         = var.kubernetes_version
-  enable_host_encryption       = var.enable_nodepools_host_encryption
+  enable_host_encryption       = var.aks_cluster_enable_host_encryption
   tags                         = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ data "azurerm_resource_group" "aks_rg" {
   count = var.resource_group_name == null ? 0 : 1
   name  = var.resource_group_name
 }
+
 resource "azurerm_proximity_placement_group" "proximity" {
   count = var.node_pools_proximity_placement ? 1 : 0
 
@@ -143,6 +144,7 @@ module "aks" {
   aks_cluster_max_pods                     = var.default_nodepool_max_pods
   aks_cluster_os_disk_size                 = var.default_nodepool_os_disk_size
   aks_cluster_node_vm_size                 = var.default_nodepool_vm_type
+  aks_cluster_enable_host_encryption       = var.enable_default_nodepool_host_encryption
   aks_cluster_node_admin                   = var.node_vm_admin
   aks_cluster_ssh_public_key               = try(file(var.ssh_public_key), "")
   aks_cluster_private_dns_zone_id          = var.aks_cluster_private_dns_zone_id
@@ -206,6 +208,7 @@ module "node_pools" {
   zones                        = (var.node_pools_availability_zone == "" || var.node_pools_proximity_placement == true) ? [] : (var.node_pools_availability_zones != null) ? var.node_pools_availability_zones : [var.node_pools_availability_zone]
   proximity_placement_group_id = element(coalescelist(azurerm_proximity_placement_group.proximity[*].id, [""]), 0)
   orchestrator_version         = var.kubernetes_version
+  enable_host_encryption       = var.enable_nodepools_host_encryption
   tags                         = var.tags
 }
 

--- a/modules/aks_node_pool/main.tf
+++ b/modules/aks_node_pool/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
   vnet_subnet_id               = var.vnet_subnet_id
   zones                        = var.zones
   fips_enabled                 = var.fips_enabled
-  enable_host_encryption       = true
+  enable_host_encryption       = var.enable_host_encryption
   proximity_placement_group_id = var.proximity_placement_group_id == "" ? null : var.proximity_placement_group_id
   vm_size                      = var.machine_type
   os_disk_size_gb              = var.os_disk_size

--- a/modules/aks_node_pool/main.tf
+++ b/modules/aks_node_pool/main.tf
@@ -10,6 +10,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale_node_pool" {
   vnet_subnet_id               = var.vnet_subnet_id
   zones                        = var.zones
   fips_enabled                 = var.fips_enabled
+  enable_host_encryption       = var.enable_host_encryption
   proximity_placement_group_id = var.proximity_placement_group_id == "" ? null : var.proximity_placement_group_id
   vm_size                      = var.machine_type
   os_disk_size_gb              = var.os_disk_size
@@ -40,6 +41,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
   vnet_subnet_id               = var.vnet_subnet_id
   zones                        = var.zones
   fips_enabled                 = var.fips_enabled
+  enable_host_encryption       = true
   proximity_placement_group_id = var.proximity_placement_group_id == "" ? null : var.proximity_placement_group_id
   vm_size                      = var.machine_type
   os_disk_size_gb              = var.os_disk_size

--- a/modules/aks_node_pool/variables.tf
+++ b/modules/aks_node_pool/variables.tf
@@ -23,6 +23,12 @@ variable "fips_enabled" {
   default     = false
 }
 
+variable "enable_host_encryption" {
+  description = "Enables host encryption on all the nodes in the Node Pool. Changing this forces a new resource to be created."
+  type        = bool
+  default     = false
+}
+
 variable "vnet_subnet_id" {
   description = "The ID of the Subnet where this Node Pool should exist. Changing this forces a new resource to be created."
   type        = string

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -13,6 +13,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   support_plan                      = var.cluster_support_tier
   role_based_access_control_enabled = true
   http_application_routing_enabled  = false
+  disk_encryption_set_id            = var.aks_node_disk_encryption_set_id
 
   # https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
   # az aks get-versions --location eastus -o table

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -52,22 +52,23 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   default_node_pool {
-    name                  = "system"
-    vm_size               = var.aks_cluster_node_vm_size
-    zones                 = var.aks_availability_zones
-    enable_auto_scaling   = var.aks_cluster_node_auto_scaling
-    enable_node_public_ip = false
-    node_labels           = {}
-    node_taints           = []
-    fips_enabled          = var.fips_enabled
-    max_pods              = var.aks_cluster_max_pods
-    os_disk_size_gb       = var.aks_cluster_os_disk_size
-    max_count             = var.aks_cluster_max_nodes
-    min_count             = var.aks_cluster_min_nodes
-    node_count            = var.aks_cluster_node_count
-    vnet_subnet_id        = var.aks_vnet_subnet_id
-    tags                  = var.aks_cluster_tags
-    orchestrator_version  = var.kubernetes_version
+    name                   = "system"
+    vm_size                = var.aks_cluster_node_vm_size
+    zones                  = var.aks_availability_zones
+    enable_auto_scaling    = var.aks_cluster_node_auto_scaling
+    enable_node_public_ip  = false
+    node_labels            = {}
+    node_taints            = []
+    fips_enabled           = var.fips_enabled
+    enable_host_encryption = var.aks_cluster_enable_host_encryption
+    max_pods               = var.aks_cluster_max_pods
+    os_disk_size_gb        = var.aks_cluster_os_disk_size
+    max_count              = var.aks_cluster_max_nodes
+    min_count              = var.aks_cluster_min_nodes
+    node_count             = var.aks_cluster_node_count
+    vnet_subnet_id         = var.aks_vnet_subnet_id
+    tags                   = var.aks_cluster_tags
+    orchestrator_version   = var.kubernetes_version
   }
 
   dynamic "service_principal" {

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -113,6 +113,12 @@ variable "aks_cluster_max_pods" {
   default     = 110
 }
 
+variable "aks_cluster_enable_host_encryption" {
+  description = "Enables host encryption on all the nodes in the Default Node Pool"
+  type        = bool
+  default     = false
+}
+
 variable "kubernetes_version" {
   description = "The AKS cluster K8s version"
   type        = string

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -119,6 +119,12 @@ variable "aks_cluster_enable_host_encryption" {
   default     = false
 }
 
+variable "aks_node_disk_encryption_set_id" {
+  description = "The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
 variable "kubernetes_version" {
   description = "The AKS cluster K8s version"
   type        = string

--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -64,6 +64,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
   size                         = var.machine_type
   admin_username               = var.vm_admin
   zone                         = var.vm_zone
+  encryption_at_host_enabled   = var.encryption_at_host_enabled
 
   #Cloud Init
   custom_data = (var.cloud_init != "" ? var.cloud_init : null)

--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -36,15 +36,16 @@ resource "azurerm_network_interface_security_group_association" "vm_nic_sg" {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk
 resource "azurerm_managed_disk" "vm_data_disk" {
-  count                = var.data_disk_count
-  name                 = format("%s-disk%02d", var.name, count.index + 1)
-  location             = var.azure_rg_location
-  resource_group_name  = var.azure_rg_name
-  storage_account_type = var.data_disk_storage_account_type
-  create_option        = "Empty"
-  disk_size_gb         = var.data_disk_size
-  zone                 = var.data_disk_zone
-  tags                 = var.tags
+  count                  = var.data_disk_count
+  name                   = format("%s-disk%02d", var.name, count.index + 1)
+  location               = var.azure_rg_location
+  resource_group_name    = var.azure_rg_name
+  storage_account_type   = var.data_disk_storage_account_type
+  create_option          = "Empty"
+  disk_size_gb           = var.data_disk_size
+  zone                   = var.data_disk_zone
+  disk_encryption_set_id = var.disk_encryption_set_id
+  tags                   = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "vm_data_disk_attach" {
@@ -79,9 +80,10 @@ resource "azurerm_linux_virtual_machine" "vm" {
   }
 
   os_disk {
-    caching              = var.os_disk_caching
-    storage_account_type = var.os_disk_storage_account_type
-    disk_size_gb         = var.os_disk_size
+    caching                = var.os_disk_caching
+    storage_account_type   = var.os_disk_storage_account_type
+    disk_size_gb           = var.os_disk_size
+    disk_encryption_set_id = var.disk_encryption_set_id
   }
 
   source_image_reference {

--- a/modules/azurerm_vm/variables.tf
+++ b/modules/azurerm_vm/variables.tf
@@ -168,3 +168,9 @@ variable "encryption_at_host_enabled" {
   type        = bool
   default     = false
 }
+
+variable "disk_encryption_set_id" {
+  description = "The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk."
+  type        = string
+  default     = null
+}

--- a/modules/azurerm_vm/variables.tf
+++ b/modules/azurerm_vm/variables.tf
@@ -162,3 +162,9 @@ variable "proximity_placement_group_id" {
   type        = string
   default     = ""
 }
+
+variable "encryption_at_host_enabled" {
+  description = "Enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. Defaults to false"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -165,10 +165,16 @@ variable "default_nodepool_availability_zones" {
   default     = ["1"]
 }
 
-variable "enable_default_nodepool_host_encryption" {
-  description = "Enables host encryption on all the nodes in the Default Node Pool"
+variable "aks_cluster_enable_host_encryption" {
+  description = "Enables host encryption on all the nodes in the Node Pool."
   type        = bool
   default     = false
+}
+
+variable "aks_node_disk_encryption_set_id" {
+  description = "The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
 }
 
 # AKS advanced network config
@@ -368,10 +374,16 @@ variable "jump_rwx_filestore_path" {
   default     = "/viya-share"
 }
 
-variable "enable_jump_vm_host_encryption" {
-  description = "Setting this variable enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. Defaults to false"
+variable "enable_vm_host_encryption" {
+  description = "Setting this variable enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. This setting applies to both Jump and NFS VM. Defaults to false"
   type        = bool
   default     = false
+}
+
+variable "vm_disk_encryption_set_id" {
+  description = "The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. This setting applies to both Jump and NFS VM."
+  type        = string
+  default     = null
 }
 
 variable "storage_type" {
@@ -436,12 +448,6 @@ variable "nfs_raid_disk_zone" {
   description = "Specifies the Availability Zone in which this Managed Disk should be located. Changing this property forces a new resource to be created."
   type        = string
   default     = null
-}
-
-variable "enable_nfs_vm_host_encryption" {
-  description = "Setting this variable enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. Defaults to false"
-  type        = bool
-  default     = false
 }
 
 ## Azure Container Registry (ACR)
@@ -529,12 +535,6 @@ variable "node_pools_availability_zones" {
 
 variable "node_pools_proximity_placement" {
   description = "Enables Node Pool Proximity Placement Group"
-  type        = bool
-  default     = false
-}
-
-variable "enable_nodepools_host_encryption" {
-  description = "Enables host encryption on all the nodes in the Node Pool. Changing this forces a new resource to be created."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -165,6 +165,12 @@ variable "default_nodepool_availability_zones" {
   default     = ["1"]
 }
 
+variable "enable_default_nodepool_host_encryption" {
+  description = "Enables host encryption on all the nodes in the Default Node Pool"
+  type        = bool
+  default     = false
+}
+
 # AKS advanced network config
 variable "aks_network_plugin" {
   description = "Network plugin to use for networking. Currently supported values are azure and kubenet. Changing this forces a new resource to be created."
@@ -362,6 +368,12 @@ variable "jump_rwx_filestore_path" {
   default     = "/viya-share"
 }
 
+variable "enable_jump_vm_host_encryption" {
+  description = "Setting this variable enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. Defaults to false"
+  type        = bool
+  default     = false
+}
+
 variable "storage_type" {
   description = "Type of Storage. Valid Values: `standard`, `ha` and `none`. `standard` creates NFS server VM, `ha` creates Azure Netapp Files"
   type        = string
@@ -424,6 +436,12 @@ variable "nfs_raid_disk_zone" {
   description = "Specifies the Availability Zone in which this Managed Disk should be located. Changing this property forces a new resource to be created."
   type        = string
   default     = null
+}
+
+variable "enable_nfs_vm_host_encryption" {
+  description = "Setting this variable enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. Defaults to false"
+  type        = bool
+  default     = false
 }
 
 ## Azure Container Registry (ACR)
@@ -511,6 +529,12 @@ variable "node_pools_availability_zones" {
 
 variable "node_pools_proximity_placement" {
   description = "Enables Node Pool Proximity Placement Group"
+  type        = bool
+  default     = false
+}
+
+variable "enable_nodepools_host_encryption" {
+  description = "Enables host encryption on all the nodes in the Node Pool. Changing this forces a new resource to be created."
   type        = bool
   default     = false
 }

--- a/vms.tf
+++ b/vms.tf
@@ -69,7 +69,8 @@ module "jump" {
   cloud_init                 = data.cloudinit_config.jump[0].rendered
   create_public_ip           = var.create_jump_public_ip
   enable_public_static_ip    = var.enable_jump_public_static_ip
-  encryption_at_host_enabled = var.enable_jump_vm_host_encryption
+  encryption_at_host_enabled = var.enable_vm_host_encryption
+  disk_encryption_set_id     = var.vm_disk_encryption_set_id
 
   # Jump VM mounts NFS path hence dependency on 'module.nfs'
   depends_on = [module.vnet, module.nfs]
@@ -110,7 +111,8 @@ module "nfs" {
   data_disk_size                 = var.nfs_raid_disk_size
   data_disk_storage_account_type = var.nfs_raid_disk_type
   data_disk_zone                 = var.nfs_raid_disk_zone
-  encryption_at_host_enabled     = var.enable_nfs_vm_host_encryption
+  encryption_at_host_enabled     = var.enable_vm_host_encryption
+  disk_encryption_set_id         = var.vm_disk_encryption_set_id
   depends_on                     = [module.vnet]
 }
 

--- a/vms.tf
+++ b/vms.tf
@@ -54,21 +54,22 @@ data "cloudinit_config" "jump" {
 module "jump" {
   source = "./modules/azurerm_vm"
 
-  count                   = var.create_jump_vm ? 1 : 0
-  name                    = "${var.prefix}-jump"
-  azure_rg_name           = local.aks_rg.name
-  azure_rg_location       = var.location
-  vnet_subnet_id          = module.vnet.subnets["misc"].id
-  machine_type            = var.jump_vm_machine_type
-  azure_nsg_id            = local.nsg.id
-  tags                    = var.tags
-  vm_admin                = var.jump_vm_admin
-  vm_zone                 = var.jump_vm_zone
-  fips_enabled            = var.fips_enabled
-  ssh_public_key          = local.ssh_public_key
-  cloud_init              = data.cloudinit_config.jump[0].rendered
-  create_public_ip        = var.create_jump_public_ip
-  enable_public_static_ip = var.enable_jump_public_static_ip
+  count                      = var.create_jump_vm ? 1 : 0
+  name                       = "${var.prefix}-jump"
+  azure_rg_name              = local.aks_rg.name
+  azure_rg_location          = var.location
+  vnet_subnet_id             = module.vnet.subnets["misc"].id
+  machine_type               = var.jump_vm_machine_type
+  azure_nsg_id               = local.nsg.id
+  tags                       = var.tags
+  vm_admin                   = var.jump_vm_admin
+  vm_zone                    = var.jump_vm_zone
+  fips_enabled               = var.fips_enabled
+  ssh_public_key             = local.ssh_public_key
+  cloud_init                 = data.cloudinit_config.jump[0].rendered
+  create_public_ip           = var.create_jump_public_ip
+  enable_public_static_ip    = var.enable_jump_public_static_ip
+  encryption_at_host_enabled = var.enable_jump_vm_host_encryption
 
   # Jump VM mounts NFS path hence dependency on 'module.nfs'
   depends_on = [module.vnet, module.nfs]
@@ -109,6 +110,7 @@ module "nfs" {
   data_disk_size                 = var.nfs_raid_disk_size
   data_disk_storage_account_type = var.nfs_raid_disk_type
   data_disk_zone                 = var.nfs_raid_disk_zone
+  encryption_at_host_enabled     = var.enable_nfs_vm_host_encryption
   depends_on                     = [module.vnet]
 }
 


### PR DESCRIPTION
## Changes:
This PR adds EncryptAtHost requirements in the VMs and AKS nodes.

- Virtual machines and virtual machine scale sets should have encryption at host enabled.
- Temp disks and cache for agent node pools in AKS clusters should be encrypted at host.

This is an optional features, to enable encryption at host for nodes and VMs you would set the following variables:

| Name | Description | Type | Default |
| :--- | :--- | ---: | ---: |
| enable_vm_host_encryption | Setting this variable enables all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host. This setting applies to both Jump and NFS VM. | bool | false |
| vm_disk_encryption_set_id | The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. This setting applies to both Jump and NFS VM. | string | null |
| aks_cluster_enable_host_encryption | Enables host encryption on all the nodes in the Node Pool. | bool | false |
| aks_node_disk_encryption_set_id | The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. Changing this forces a new resource to be created. | string | null |

By default, when using AKS, OS and data disks use server-side encryption with platform-managed keys. The caches for these disks are encrypted at rest with platform-managed keys. You can specify your own managed keys following [Bring your own keys (BYOK) with Azure disks in Azure Kubernetes Service](https://learn.microsoft.com/en-us/azure/aks/azure-disk-customer-managed-keys). The caches for these disks are also encrypted using the key you specify.

When using customer-managed-keys, ensure you have the proper AKS credentials. The managed identity needs to have contributor access to the resource group where the diskencryptionset is deployed. Otherwise, you'll get an error suggesting that the managed identity does not have permissions.
Also, make sure the VNet of your deployment has access to the Key Vault which has the diskencryptionset. 
Note: Adding the subnet service endpoints makes the process smooth.

## Tests:
|Scenario|Description|Order Cadence|Verification|
|:----|:----|:----|:----|
|1|Defaults, no changes|Fast 2020|Transparent to user, no changes|
|2|Set `enable_vm_host_encryption = true`, `aks_cluster_enable_host_encryption = true`|fast:2020| Encryption at host enabled with platform-managed keys on VM and nodes in nodepools |
|3|Set `enable_vm_host_encryption = true`, `vm_disk_encryption_set_id = "<disk_encryption_set_id>"`, `aks_cluster_enable_host_encryption = true`, `aks_node_disk_encryption_set_id = "<disk_encryption_set_id>"`|fast:2020| Encryption at host enabled with customer-managed keys on VM and nodes in nodepools |
