### PR TITLE
fix: (IAC-1410) Updated the default probe path

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -827,7 +827,7 @@ variable "app_gateway_defaults" {
     waf_policy                       = null
     probe = [{
       name = "default-probe"
-      path = "/SASLogon/apiMeta"
+      path = "/SASLogon/login"
     }]
   }
 }


### PR DESCRIPTION
## Changes:
This PR updates the default probe path from `/SASLogon/apiMeta` to `/SASLogon/login` based on product teams recommendation.

## Test:
Verified Application gateway creation with default probe was successful. After deploying SAS Viya the backend health of the gateway was healthy. See detailed test result in the internal ticket.