### PR TITLE
feat: (IAC-600) Add support for Microsoft Entra authentication with Kubernetes RBAC

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -8,6 +8,7 @@ Supported configuration variables are listed in the tables below.  All variables
   - [Table of Contents](#table-of-contents)
   - [Required Variables](#required-variables)
     - [Azure Authentication](#azure-authentication)
+  - [Role Based Access Control](#role-based-access-control)
   - [Admin Access](#admin-access)
   - [Security](#security)
   - [Networking](#networking)
@@ -52,6 +53,20 @@ For details on how to retrieve that information, see [Azure Help Topics](./user/
 **NOTE:** Values for `subscription_id` and `tenant_id` are always required. `client_id` and `client_secret` are required when using a Service Principal. `use_msi=true` is required when using an Azure VM Managed Identity.
 
 For recommendations on how to set these variables in your environment, see [Authenticating Terraform to Access Azure](./user/TerraformAzureAuthentication.md).
+
+## Role Based Access Control
+
+The ability to manage RBAC for Kubernetes resources from Azure gives you the choice to manage RBAC for the cluster resources either using Azure or native Kubernetes mechanisms. For details see [Azure role-based access control](https://docs.microsoft.com/en-us/azure/aks/concepts-identity#azure-rbac-for-kubernetes-authorization).
+
+Following are the possible ways to configure Authentication and Authorization in an AKS cluster:
+1. Authentication using local accounts with Kubernetes RBAC. This is traditionally used and current default, see details [here](https://learn.microsoft.com/en-us/azure/aks/concepts-identity#kubernetes-rbac)
+2. Microsoft Entra authentication with Kubernetes RBAC. See details [here](https://learn.microsoft.com/en-us/azure/aks/azure-ad-rbac)
+
+| Name | Description | Type | Default |
+| :--- | ---: | ---: | ---: |
+| rbac_aad_enabled | Enables Azure Active Directory integration with Kubernetes RBAC. | bool  | false |
+| rbac_aad_admin_group_object_ids | A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster. | list(string) | null |
+| rbac_aad_tenant_id | (Optional) The Tenant ID used for Azure Active Directory Application. If this isn't specified the Tenant ID of the current Subscription is used.| string  | |
 
 ## Admin Access
 

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,9 @@ module "aks" {
   aks_uai_id                               = local.aks_uai_id
   client_id                                = var.client_id
   client_secret                            = var.client_secret
+  rbac_aad_tenant_id                       = var.rbac_aad_tenant_id
+  rbac_aad_enabled                         = var.rbac_aad_enabled
+  rbac_aad_admin_group_object_ids          = var.rbac_aad_admin_group_object_ids
   aks_private_cluster                      = var.cluster_api_mode == "private" ? true : false
   depends_on                               = [module.vnet]
 }

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -52,6 +52,16 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 
+  dynamic "azure_active_directory_role_based_access_control" {
+    for_each = var.rbac_aad_enabled ? [1] : []
+    content {
+      managed                 = true
+      tenant_id               = var.rbac_aad_tenant_id
+      admin_group_object_ids  = var.rbac_aad_admin_group_object_ids
+      azure_rbac_enabled      = false
+    }
+  }
+
   default_node_pool {
     name                   = "system"
     vm_size                = var.aks_cluster_node_vm_size

--- a/modules/azure_aks/outputs.tf
+++ b/modules/azure_aks/outputs.tf
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 output "client_key" {
-  value = azurerm_kubernetes_cluster.aks.kube_config[0].client_key
+  value = var.rbac_aad_enabled ? azurerm_kubernetes_cluster.aks.kube_admin_config[0].client_key : azurerm_kubernetes_cluster.aks.kube_config[0].client_key
 }
 
 output "client_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate
+  value = var.rbac_aad_enabled ? azurerm_kubernetes_cluster.aks.kube_admin_config[0].client_certificate : azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate
 }
 
 output "cluster_ca_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate
+  value = var.rbac_aad_enabled ? azurerm_kubernetes_cluster.aks.kube_admin_config[0].cluster_ca_certificate : azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate
 }
 
 output "cluster_username" {
@@ -18,7 +18,7 @@ output "cluster_username" {
 }
 
 output "cluster_password" {
-  value = azurerm_kubernetes_cluster.aks.kube_config[0].password
+  value = var.rbac_aad_enabled ? azurerm_kubernetes_cluster.aks.kube_admin_config[0].password : azurerm_kubernetes_cluster.aks.kube_config[0].password
 }
 
 output "kube_config" {

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -22,6 +22,24 @@ variable "aks_cluster_location" {
   default     = "eastus"
 }
 
+variable "rbac_aad_enabled" {
+  type        = bool
+  description = "Enables Azure Active Directory integration with Kubernetes RBAC."
+  default     = false
+}
+
+variable "rbac_aad_admin_group_object_ids" {
+  type        = list(string)
+  description = "A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster."
+  default     = null
+}
+
+variable "rbac_aad_tenant_id" {
+  type        = string
+  description = "(Optional) The Tenant ID used for Azure Active Directory Application. If this isn't specified the Tenant ID of the current Subscription is used."
+  default     = null
+}
+
 variable "aks_cluster_sku_tier" {
   description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free, Standard (which includes the Uptime SLA) and Premium. Defaults to Free"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,25 @@ variable "location" {
   default     = "eastus"
 }
 
+## Azure AD
+variable "rbac_aad_enabled" {
+  type        = bool
+  description = "Enables Azure Active Directory integration with Kubernetes RBAC."
+  default     = false
+}
+
+variable "rbac_aad_admin_group_object_ids" {
+  type        = list(string)
+  description = "A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster."
+  default     = null
+}
+
+variable "rbac_aad_tenant_id" {
+  type        = string
+  description = "(Optional) The Tenant ID used for Azure Active Directory Application. If this isn't specified the Tenant ID of the current Subscription is used."
+  default     = null
+}
+
 variable "aks_cluster_sku_tier" {
   description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free, Standard (which includes the Uptime SLA) and Premium. Defaults to Free"
   type        = string


### PR DESCRIPTION
## Changes: 
This PR adds support for Microsoft Entra authentication with Kubernetes RBAC. For more details on Microsoft Entra authentication with Kubernetes RBAC see Azure documentation [here](https://learn.microsoft.com/en-us/azure/aks/azure-ad-rbac).

With this new feature user will have two options to configure Authentication and Authorization in an AKS cluster:
1. Local Accounts with Kubernetes RBAC.  -- Current default
2. Microsoft Entra authentication with Kubernetes RBAC.

## Tests:
Verified following scenarios:

|Scenario|Task|Cadence|kubernetes_version|Notes|
|:----|:----|:----|:----|:----|
|1|create_static_kubeconfig = true, rbac_aad_enabled = true, rbac_aad_admin_group_object_ids = ["****"]|fast:2020|1.28|Authentication and Authorization is set to `Microsoft Entra authentication with Kubernetes RBAC`|
|2|create_static_kubeconfig = false, rbac_aad_enabled = true, rbac_aad_admin_group_object_ids = ["*****"]|fast:2020|1.28|Authentication and Authorization is set to `Microsoft Entra authentication with Kubernetes RBAC`|
|3|create_static_kubeconfig = true, rbac_aad_enabled = false, rbac_aad_admin_group_object_ids = ["*****"]|fast:2020|1.28|Authentication and Authorization is set to `Local Accounts with Kubernetes RBAC`|
|4|create_static_kubeconfig = false, rbac_aad_enabled = false, rbac_aad_admin_group_object_ids = ["******"]|fast:2020|1.28|Authentication and Authorization is set to `Local Accounts with Kubernetes RBAC`|
|5|OOTB, all defaults |fast:2020|1.28|No changes, Authentication and Authorization is set to `Local Accounts with Kubernetes RBAC` |
|6|create_static_kubeconfig = false, rbac_aad_enabled = true, rbac_aad_admin_group_object_ids = null or not specified|fast:2020|1.28|Authentication and Authorization is set to `Microsoft Entra authentication with Kubernetes RBAC`|