### PR TITLE
feat: (IAC-1024) Update IAC Sample Sizing

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -219,7 +219,7 @@ Ubuntu 20.04 LTS is the operating system used on the Jump/NFS servers. Ubuntu cr
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | node_vm_admin | Operating system Admin User for VMs of AKS cluster nodes | string | "azureuser" | |
-| default_nodepool_vm_type | Type of the default node pool VMs | string | "Standard_D8s_v4" | |
+| default_nodepool_vm_type | Type of the default node pool VMs | string | "Standard_E8s_v5" | |
 | default_nodepool_os_disk_size | Disk size for default node pool VMs in GB | number | 128 ||
 | default_nodepool_max_pods | Maximum number of pods that can run on each | number | 110 | Changing this forces a new resource to be created. |
 | default_nodepool_min_nodes | Minimum and initial number of nodes for the default node pool | number | 1 |  Value must be between 0 and 100. Setting min and max node counts the same disables autoscaling. |
@@ -247,7 +247,7 @@ The default values for the `node_pools` variable are as follows:
 ```yaml
 {
   cas = {
-    "machine_type"          = "Standard_E16s_v3"
+    "machine_type"          = "Standard_E16ds_v5"
     "os_disk_size"          = 200
     "min_nodes"             = 0
     "max_nodes"             = 5
@@ -258,7 +258,7 @@ The default values for the `node_pools` variable are as follows:
     }
   },
   compute = {
-    "machine_type"          = "Standard_E16s_v3"
+    "machine_type"          = "Standard_D4ds_v5"
     "os_disk_size"          = 200
     "min_nodes"             = 1
     "max_nodes"             = 5
@@ -270,7 +270,7 @@ The default values for the `node_pools` variable are as follows:
     }
   },
   stateless = {
-    "machine_type"          = "Standard_D16s_v3"
+    "machine_type"          = "Standard_D4s_v5"
     "os_disk_size"          = 200
     "min_nodes"             = 0
     "max_nodes"             = 5
@@ -281,7 +281,7 @@ The default values for the `node_pools` variable are as follows:
     }
   },
   stateful = {
-    "machine_type"          = "Standard_D8s_v3"
+    "machine_type"          = "Standard_D4s_v5"
     "os_disk_size"          = 200
     "min_nodes"             = 0
     "max_nodes"             = 3
@@ -320,10 +320,10 @@ When `storage_type=standard`, a NFS Server VM is created, only when these variab
 | create_nfs_public_ip | Add public ip to the NFS server VM | bool | false | |
 | enable_nfs_public_static_ip | Enables `Static` allocation method for the public IP address of NFS Server. Setting false will enable `Dynamic` allocation method | bool | true | Only used with `create_nfs_public_ip=true` |
 | nfs_vm_admin | OS Admin User for the NFS server VM | string | "nfsuser" | |
-| nfs_vm_machine_type | SKU to use for NFS server VM | string | "Standard_D8s_v4" | To check for valid types for your subscription, run: `az vm list-skus --resource-type virtualMachines --subscription $subscription --location $location -o table`|
+| nfs_vm_machine_type | SKU to use for NFS server VM | string | "Standard_D4s_v4" | To check for valid types for your subscription, run: `az vm list-skus --resource-type virtualMachines --subscription $subscription --location $location -o table`|
 | nfs_vm_zone | Zone in which NFS server VM should be created | string | null | |
 | nfs_raid_disk_type | Managed disk types | string | "Standard_LRS" | Supported values: Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS. When using `UltraSSD_LRS`, `nfs_vm_zone` and `nfs_raid_disk_zone` must be specified. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd) for limitations on Availability Zones and VM types. |
-| nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 128 | |
+| nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 256 | |
 | nfs_raid_disk_zone | The Availability Zone in which the Managed Disk should be located. Changing this property forces a new resource to be created. | string | null | |
 
 ### Azure NetApp Files (only when `storage_type=ha`)
@@ -368,8 +368,8 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| sku_name| The SKU Name for the PostgreSQL Flexible Server | string | "GP_Standard_D16s_v3" | The name pattern is the SKU, followed by the tier + family + cores (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3).|
-| storage_mb | The max storage allowed for the PostgreSQL Flexible Server | number | 65536 | Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432. |
+| sku_name| The SKU Name for the PostgreSQL Flexible Server | string | "GP_Standard_D4ds_v5" | The name pattern is the SKU, followed by the tier + family + cores (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3).|
+| storage_mb | The max storage allowed for the PostgreSQL Flexible Server | number | 131072 | Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432. |
 | backup_retention_days | Backup retention days for the PostgreSQL Flexible server | number | 7 | Supported values are between 7 and 35 days. |
 | geo_redundant_backup_enabled | Enable Geo-redundant or not for server backup | bool | false | Not supported for the basic tier. |
 | administrator_login | The Administrator Login for the PostgreSQL Flexible Server. Changing this forces a new resource to be created. | string | "pgadmin" | The admin login name cannot be azure_superuser, azure_pg_admin, admin, administrator, root, guest, or public. It cannot start with pg_. See: [Microsoft Quickstart Server Database](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/quickstart-create-server-portal) |
@@ -395,8 +395,8 @@ postgres_servers = {
       ]
   },
   cds-postgres = {
-    sku_name                     = "GP_Standard_D16s_v3"
-    storage_mb                   = 65536
+    sku_name                     = "GP_Standard_D4ds_v5"
+    storage_mb                   = 131072
     backup_retention_days        = 7
     administrator_login          = "pgadmin"
     administrator_password       = "1tsAB3aut1fulDay"

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -320,7 +320,7 @@ When `storage_type=standard`, a NFS Server VM is created, only when these variab
 | create_nfs_public_ip | Add public ip to the NFS server VM | bool | false | |
 | enable_nfs_public_static_ip | Enables `Static` allocation method for the public IP address of NFS Server. Setting false will enable `Dynamic` allocation method | bool | true | Only used with `create_nfs_public_ip=true` |
 | nfs_vm_admin | OS Admin User for the NFS server VM | string | "nfsuser" | |
-| nfs_vm_machine_type | SKU to use for NFS server VM | string | "Standard_D4s_v4" | To check for valid types for your subscription, run: `az vm list-skus --resource-type virtualMachines --subscription $subscription --location $location -o table`|
+| nfs_vm_machine_type | SKU to use for NFS server VM | string | "Standard_D4s_v5" | To check for valid types for your subscription, run: `az vm list-skus --resource-type virtualMachines --subscription $subscription --location $location -o table`|
 | nfs_vm_zone | Zone in which NFS server VM should be created | string | null | |
 | nfs_raid_disk_type | Managed disk types | string | "Standard_LRS" | Supported values: Standard_LRS, Premium_LRS, StandardSSD_LRS or UltraSSD_LRS. When using `UltraSSD_LRS`, `nfs_vm_zone` and `nfs_raid_disk_zone` must be specified. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd) for limitations on Availability Zones and VM types. |
 | nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 256 | |

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -108,6 +108,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_vm_machine_type  = "Standard_D4s_v5"
 nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -47,12 +47,12 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -63,7 +63,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -75,10 +75,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -86,10 +86,10 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
@@ -108,6 +108,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D8s_v4"
-nfs_raid_disk_size   = 128
+nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -36,12 +36,12 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -52,7 +52,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -76,10 +76,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -87,10 +87,10 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
@@ -109,6 +109,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D8s_v4"
-nfs_raid_disk_size   = 128
+nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -109,6 +109,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_vm_machine_type  = "Standard_D4s_v5"
 nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -34,12 +34,12 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 2
     "max_nodes"    = 3
@@ -50,7 +50,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 2
     "max_nodes"    = 3
@@ -62,10 +62,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 2
-    "max_nodes"    = 3
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -73,7 +73,7 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 2
     "max_nodes"    = 3

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -76,5 +76,5 @@ storage_type = "standard"
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
 nfs_vm_machine_type  = "Standard_D4s_v4"
-nfs_raid_disk_size   = 128
+nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -75,6 +75,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_vm_machine_type  = "Standard_D4s_v5"
 nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-postgres.tfvars
+++ b/examples/sample-input-postgres.tfvars
@@ -149,6 +149,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_vm_machine_type  = "Standard_D4s_v5"
 nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-postgres.tfvars
+++ b/examples/sample-input-postgres.tfvars
@@ -88,12 +88,12 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -104,7 +104,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -116,10 +116,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -127,10 +127,10 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
@@ -149,6 +149,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D8s_v4"
-nfs_raid_disk_size   = 128
+nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -35,7 +35,7 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 ## Azure Proximity Placement / Availability Zone config
 #  !NOTE! - If proximity placement groups are required for your deployment
@@ -50,7 +50,7 @@ node_pools_availability_zone   = ""
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -61,7 +61,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -73,10 +73,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
-    "min_nodes"    = 2
-    "max_nodes"    = 2
+    "min_nodes"    = 1
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -84,10 +84,10 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
-    "min_nodes"    = 3
-    "max_nodes"    = 3
+    "min_nodes"    = 1
+    "max_nodes"    = 2
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
@@ -107,6 +107,6 @@ create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
 nfs_vm_zone          = 1
 
-nfs_raid_disk_size  = 128
+nfs_raid_disk_size  = 256
 nfs_raid_disk_type  = "Standard_LRS"
 nfs_raid_disk_zone = "1"

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -36,13 +36,13 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 # AKS Node Pools config
 node_pools = {
 
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -53,7 +53,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -65,10 +65,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -76,10 +76,10 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
@@ -114,8 +114,8 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D8s_v4"
-nfs_raid_disk_size   = 128
+nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"
 
 ## HA storage type

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -114,7 +114,7 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_vm_machine_type  = "Standard_D4s_v5"
 nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -97,6 +97,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_vm_machine_type  = "Standard_D4s_v5"
 nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -36,12 +36,12 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D8s_v4"
+default_nodepool_vm_type   = "Standard_E8s_v5"
 
 # AKS Node Pools config
 node_pools = {
   cas = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -52,7 +52,7 @@ node_pools = {
     }
   },
   compute = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_D4ds_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -64,10 +64,10 @@ node_pools = {
     }
   },
   stateless = {
-    "machine_type" = "Standard_D16s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
@@ -75,10 +75,10 @@ node_pools = {
     }
   },
   stateful = {
-    "machine_type" = "Standard_D8s_v3"
+    "machine_type" = "Standard_D4s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "max_pods"     = 110
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
@@ -97,6 +97,6 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_machine_type  = "Standard_D8s_v4"
-nfs_raid_disk_size   = 128
+nfs_vm_machine_type  = "Standard_D4s_v4"
+nfs_raid_disk_size   = 256
 nfs_raid_disk_type   = "Standard_LRS"

--- a/modules/azurerm_postgresql_flex/variables.tf
+++ b/modules/azurerm_postgresql_flex/variables.tf
@@ -19,13 +19,13 @@ variable "server_name" {
 variable "sku_name" {
   description = "The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the tier + name pattern (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3)."
   type        = string
-  default     = "GP_Standard_D16s_v3"
+  default     = "GP_Standard_D4ds_v5"
 }
 
 variable "storage_mb" {
   description = "The max storage allowed for the PostgreSQL Flexible Server. Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432."
   type        = number
-  default     = 65536
+  default     = 131072
 }
 
 variable "backup_retention_days" {

--- a/modules/azurerm_vm/variables.tf
+++ b/modules/azurerm_vm/variables.tf
@@ -94,7 +94,7 @@ variable "data_disk_count" {
 variable "data_disk_size" {
   description = "Specifies the size of the managed disk to create in GB."
   type        = number
-  default     = 128
+  default     = 256
 }
 
 variable "data_disk_caching" {

--- a/variables.tf
+++ b/variables.tf
@@ -145,7 +145,7 @@ variable "postgres_public_access_cidrs" {
 variable "default_nodepool_vm_type" {
   description = "The default virtual machine size for the Kubernetes agents"
   type        = string
-  default     = "Standard_D8s_v4"
+  default     = "Standard_E8s_v5"
 }
 
 variable "kubernetes_version" {
@@ -301,8 +301,8 @@ variable "postgres_server_defaults" {
   description = ""
   type        = any
   default = {
-    sku_name                     = "GP_Standard_D16s_v3"
-    storage_mb                   = 65536
+    sku_name                     = "GP_Standard_D4ds_v5"
+    storage_mb                   = 131072
     backup_retention_days        = 7
     geo_redundant_backup_enabled = false
     administrator_login          = "pgadmin"
@@ -431,7 +431,7 @@ variable "enable_nfs_public_static_ip" {
 variable "nfs_vm_machine_type" {
   description = "SKU which should be used for this Virtual Machine"
   type        = string
-  default     = "Standard_D8s_v4"
+  default     = "Standard_D4s_v4"
 }
 
 variable "nfs_vm_admin" {
@@ -449,7 +449,7 @@ variable "nfs_vm_zone" {
 variable "nfs_raid_disk_size" {
   description = "Size in Gb for each disk of the RAID5 cluster, when storage_type=standard"
   type        = number
-  default     = 128
+  default     = 256
 }
 
 variable "nfs_raid_disk_type" {
@@ -572,7 +572,7 @@ variable "node_pools" {
 
   default = {
     cas = {
-      "machine_type" = "Standard_E16s_v3"
+      "machine_type" = "Standard_E16ds_v5"
       "os_disk_size" = 200
       "min_nodes"    = 0
       "max_nodes"    = 5
@@ -583,7 +583,7 @@ variable "node_pools" {
       }
     },
     compute = {
-      "machine_type" = "Standard_E16s_v3"
+      "machine_type" = "Standard_D4ds_v5"
       "os_disk_size" = 200
       "min_nodes"    = 1
       "max_nodes"    = 5
@@ -595,7 +595,7 @@ variable "node_pools" {
       }
     },
     stateless = {
-      "machine_type" = "Standard_D16s_v3"
+      "machine_type" = "Standard_D4s_v5"
       "os_disk_size" = 200
       "min_nodes"    = 0
       "max_nodes"    = 5
@@ -606,7 +606,7 @@ variable "node_pools" {
       }
     },
     stateful = {
-      "machine_type" = "Standard_D8s_v3"
+      "machine_type" = "Standard_D4s_v5"
       "os_disk_size" = 200
       "min_nodes"    = 0
       "max_nodes"    = 3

--- a/variables.tf
+++ b/variables.tf
@@ -431,7 +431,7 @@ variable "enable_nfs_public_static_ip" {
 variable "nfs_vm_machine_type" {
   description = "SKU which should be used for this Virtual Machine"
   type        = string
-  default     = "Standard_D4s_v4"
+  default     = "Standard_D4s_v5"
 }
 
 variable "nfs_vm_admin" {


### PR DESCRIPTION
### Changes

Updated examples, defaults, and docs to line up with sizing recommendations.

### Tests

| Scenario | Provider | Example File                    | kubernetes_version | Order  | Cadence   |
|----------|----------|---------------------------------|--------------------|--------|-----------|
| 1        | Azure    | sample-input.tfvars             | v1.28.9            | * | fast:2020 |
| 2        | Azure    | sample-input-connect.tfvars     | v1.28.9            |        |           |
| 3        | Azure    | sample-input-defaults.tfvars    | v1.28.9            |        |           |
| 4        | Azure    | sample-input-minimal.tfvars     | v1.28.9            |        |           |
| 5        | Azure    | sample-input-ppg.tfvars         | v1.28.9            |        |           |
| 6        | Azure    | sample-input-singlestore.tfvars | v1.28.9            |        |           |

