### PR TITLE
Added option to specify the name of node_resource_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,6 +215,7 @@ module "node_pools" {
   orchestrator_version         = var.kubernetes_version
   enable_host_encryption       = var.aks_cluster_enable_host_encryption
   tags                         = var.tags
+  linux_os_config              = each.value.linux_os_config
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server

--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,7 @@ module "aks" {
   aks_cluster_dns_prefix                   = "${var.prefix}-aks"
   aks_cluster_sku_tier                     = var.aks_cluster_sku_tier
   aks_cluster_location                     = var.location
+  node_resource_group_name                 = var.node_resource_group_name != "" ? var.node_resource_group_name : "MC_${local.aks_rg.name}_${var.prefix}-aks_${var.location}"
   cluster_support_tier                     = var.cluster_support_tier
   fips_enabled                             = var.fips_enabled
   aks_cluster_node_auto_scaling            = var.default_nodepool_min_nodes == var.default_nodepool_max_nodes ? false : true

--- a/modules/aks_node_pool/main.tf
+++ b/modules/aks_node_pool/main.tf
@@ -32,6 +32,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale_node_pool" {
   lifecycle {
     ignore_changes = [node_count]
   }
+
+  linux_os_config {
+    sysctl_config {
+      vm_max_map_count  = try(var.linux_os_config.sysctl_config.vm_max_map_count,null)
+    }
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
@@ -57,4 +63,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
   node_taints          = var.node_taints
   orchestrator_version = var.orchestrator_version
   tags                 = var.tags
+  
+  linux_os_config {
+    sysctl_config {
+      vm_max_map_count  = try(var.linux_os_config.sysctl_config.vm_max_map_count,null)
+    }
+  }
 }

--- a/modules/aks_node_pool/variables.tf
+++ b/modules/aks_node_pool/variables.tf
@@ -136,3 +136,13 @@ variable "proximity_placement_group_id" {
 #   type        = number
 #   default     = -1
 # }
+
+variable "linux_os_config"{
+  description = "Specifications of linux os config. Changing this forces a new resource to be created."
+  type = object({
+      sysctl_config = optional(object({
+        vm_max_map_count = optional(number)
+        }))
+      })
+  default = {}
+}

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -6,6 +6,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   name                       = var.aks_cluster_name
   location                   = var.aks_cluster_location
   resource_group_name        = var.aks_cluster_rg
+  node_resource_group        = var.node_resource_group_name != "" ? var.node_resource_group_name : "MC_${var.aks_cluster_rg}_${var.aks_cluster_name}_${var.aks_cluster_location}"
   dns_prefix                 = var.aks_private_cluster == false || var.aks_cluster_private_dns_zone_id == "" ? var.aks_cluster_dns_prefix : null
   dns_prefix_private_cluster = var.aks_private_cluster && var.aks_cluster_private_dns_zone_id != "" ? var.aks_cluster_dns_prefix : null
 
@@ -134,7 +135,7 @@ data "azurerm_public_ip" "cluster_public_ip" {
 
   # effective_outbound_ips is a set of strings, that needs to be converted to a list type
   name                = split("/", tolist(azurerm_kubernetes_cluster.aks.network_profile[0].load_balancer_profile[0].effective_outbound_ips)[0])[8]
-  resource_group_name = "MC_${var.aks_cluster_rg}_${var.aks_cluster_name}_${var.aks_cluster_location}"
+  resource_group_name = var.node_resource_group_name != "" ? var.node_resource_group_name : "MC_${var.aks_cluster_rg}_${var.aks_cluster_name}_${var.aks_cluster_location}"
 
   depends_on = [azurerm_kubernetes_cluster.aks]
 }

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -265,3 +265,8 @@ variable "aks_cluster_private_dns_zone_id" {
   type    = string
   default = ""
 }
+
+variable "node_resource_group_name" {
+  type    = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -839,3 +839,8 @@ variable "message_broker_capacity" {
   type        = number
   default     = 1
 }
+
+variable "node_resource_group_name" {
+  type    = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -568,6 +568,11 @@ variable "node_pools" {
     max_pods     = string
     node_taints  = list(string)
     node_labels  = map(string)
+    linux_os_config = optional(object({
+      sysctl_config = optional(object({
+        vm_max_map_count = optional(number)
+      }))
+    }))
   }))
 
   default = {


### PR DESCRIPTION
Added option to specify the name of **node_resource_group**.

The default is set to be the the original format that starts with MC.

According https://learn.microsoft.com/en-us/azure/aks/faq#why-are-two-resource-groups-created-with-aks, the default name of node resource group is in a format of MC_myResourceGroup_myAKSCluster_eastus. 

Introduced in https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster, the optional argument node_resource_group allows user to specify the name of name of **node_resource_group**.

