### PR TITLE
Added the option for vm max_map_count.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -214,6 +214,7 @@ module "node_pools" {
   orchestrator_version         = var.kubernetes_version
   enable_host_encryption       = var.aks_cluster_enable_host_encryption
   tags                         = var.tags
+  linux_os_config              = each.value.linux_os_config
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server

--- a/modules/aks_node_pool/main.tf
+++ b/modules/aks_node_pool/main.tf
@@ -32,6 +32,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale_node_pool" {
   lifecycle {
     ignore_changes = [node_count]
   }
+
+  linux_os_config {
+    sysctl_config {
+      vm_max_map_count  = try(var.linux_os_config.sysctl_config.vm_max_map_count,null)
+    }
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
@@ -57,4 +63,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
   node_taints          = var.node_taints
   orchestrator_version = var.orchestrator_version
   tags                 = var.tags
+
+  linux_os_config {
+    sysctl_config {
+      vm_max_map_count  = try(var.linux_os_config.sysctl_config.vm_max_map_count,null)
+    }
+  }
 }

--- a/modules/aks_node_pool/variables.tf
+++ b/modules/aks_node_pool/variables.tf
@@ -136,3 +136,13 @@ variable "proximity_placement_group_id" {
 #   type        = number
 #   default     = -1
 # }
+
+variable "linux_os_config"{
+  description = "Specifications of linux os config. Changing this forces a new resource to be created."
+  type = object({
+      sysctl_config = optional(object({
+        vm_max_map_count = optional(number)
+        }))
+      })
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -568,6 +568,11 @@ variable "node_pools" {
     max_pods     = string
     node_taints  = list(string)
     node_labels  = map(string)
+    linux_os_config = optional(object({
+      sysctl_config = optional(object({
+        vm_max_map_count = optional(number)
+      }))
+    }))
   }))
 
   default = {


### PR DESCRIPTION
This PR request added the option to configure  vm max_map_count in node_pool.

linux_os_config, sysctl_config and vm max_map_count do not have to be specified in tfvars as they are set to optional. 

The default value of vm max_map_count is null if it is not specified.

Reference: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool
