### PR TITLE
fix: (PSKD-886) Update AZ cli path for container-structure-test

### DIFF
--- a/container-structure-test.yaml
+++ b/container-structure-test.yaml
@@ -9,7 +9,7 @@ fileExistenceTests:
     shouldExist: true
     permissions: '-rwxr-xr-x'
   - name: 'azure-cli'
-    path: '/usr/local/bin/az'
+    path: '/usr/bin/az'
     shouldExist: true
     permissions: '-rwxr-xr-x'
 


### PR DESCRIPTION
The GitHub Workflow action for container-structure-test fails as the path for AZ has been updated.

Earlier the az cli would get installed here: `/usr/local/bin/az` whereas with the new az cli v2.64.0 that location has been updated to `/usr/bin/az`.

This change updates the container-structure-test with correct path to fix the failing GitHub action.