### PR TITLE
fix: (PSKD-815) Update tflint module error

### DIFF
--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -9,7 +9,7 @@
 
 config {
   # Enables module inspection.
-  module = true
+  call_module_type = "all"
 }
 
 plugin "azurerm" {


### PR DESCRIPTION
## Changes:
The TFLint config; "module" attribute was removed in v0.54.0. Updated code to use "call_module_type" instead.