### PR TITLE
PMFR4PLTFND-1316:  add rbac_aad_azure_rbac_enabled var

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -61,10 +61,12 @@ The ability to manage RBAC for Kubernetes resources from Azure gives you the cho
 Following are the possible ways to configure Authentication and Authorization in an AKS cluster:
 1. Authentication using local accounts with Kubernetes RBAC. This is traditionally used and current default, see details [here](https://learn.microsoft.com/en-us/azure/aks/concepts-identity#kubernetes-rbac)
 2. Microsoft Entra authentication with Kubernetes RBAC. See details [here](https://learn.microsoft.com/en-us/azure/aks/azure-ad-rbac)
+3. Microsoft Entra authentication with Azure RBAC. See details [here](https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac)
 
 | Name | Description | Type | Default |
 | :--- | ---: | ---: | ---: |
 | rbac_aad_enabled | Enables Azure Active Directory integration with Kubernetes RBAC. | bool  | false |
+| rbac_aad_azure_rbac_enabled | Enables Azure RBAC.  If false, Kubernetes RBAC is used.  Only relevant if rbac_aad_enabled is true. | bool  | false |
 | rbac_aad_admin_group_object_ids | A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster. | list(string) | null |
 | rbac_aad_tenant_id | (Optional) The Tenant ID used for Azure Active Directory Application. If this isn't specified the Tenant ID of the current Subscription is used.| string  | |
 

--- a/main.tf
+++ b/main.tf
@@ -168,6 +168,7 @@ module "aks" {
   client_secret                            = var.client_secret
   rbac_aad_tenant_id                       = var.rbac_aad_tenant_id
   rbac_aad_enabled                         = var.rbac_aad_enabled
+  rbac_aad_azure_rbac_enabled              = var.rbac_aad_azure_rbac_enabled
   rbac_aad_admin_group_object_ids          = var.rbac_aad_admin_group_object_ids
   aks_private_cluster                      = var.cluster_api_mode == "private" ? true : false
   depends_on                               = [module.vnet]

--- a/modules/azure_aks/main.tf
+++ b/modules/azure_aks/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     content {
       tenant_id              = var.rbac_aad_tenant_id
       admin_group_object_ids = var.rbac_aad_admin_group_object_ids
-      azure_rbac_enabled     = false
+      azure_rbac_enabled     = var.rbac_aad_azure_rbac_enabled
     }
   }
 

--- a/modules/azure_aks/variables.tf
+++ b/modules/azure_aks/variables.tf
@@ -24,7 +24,13 @@ variable "aks_cluster_location" {
 
 variable "rbac_aad_enabled" {
   type        = bool
-  description = "Enables Azure Active Directory integration with Kubernetes RBAC."
+  description = "Enables Azure Active Directory integration with Kubernetes or Azure RBAC."
+  default     = false
+}
+
+variable "rbac_aad_azure_rbac_enabled" {
+  type        = bool
+  description = "Enables Azure RBAC.  If false, Kubernetes RBAC is used.  Only relevant if rbac_aad_enabled is true."
   default     = false
 }
 
@@ -39,6 +45,7 @@ variable "rbac_aad_tenant_id" {
   description = "(Optional) The Tenant ID used for Azure Active Directory Application. If this isn't specified the Tenant ID of the current Subscription is used."
   default     = null
 }
+
 
 variable "aks_cluster_sku_tier" {
   description = "The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free, Standard (which includes the Uptime SLA) and Premium. Defaults to Free"

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,13 @@ variable "location" {
 ## Azure AD
 variable "rbac_aad_enabled" {
   type        = bool
-  description = "Enables Azure Active Directory integration with Kubernetes RBAC."
+  description = "Enables Azure Active Directory integration with Kubernetes or Azure RBAC."
+  default     = false
+}
+
+variable "rbac_aad_azure_rbac_enabled" {
+  type        = bool
+  description = "Enables Azure RBAC.  If false, Kubernetes RBAC is used.  Only relevant if rbac_aad_enabled is true."
   default     = false
 }
 


### PR DESCRIPTION
Ran two tests.  One with `rbac_aad_azure_rbac_enabled` set to true, which produced an aks cluster with:
```
Authentication and Authorization
Microsoft Entra ID authentication with Azure RBAC
```
and another with the variable omitted entirely, which produced an aks cluster with:
```
Authentication and Authorization
Microsoft Entra ID authentication with Kubernetes RBAC
```
which is consistent with current default behavior