### PR TITLE
fix: (PSKD-975) Add public_network_access_enabled to azurerm_postgresql_flexible_server resource

### DIFF
--- a/modules/azurerm_postgresql_flex/main.tf
+++ b/modules/azurerm_postgresql_flex/main.tf
@@ -37,7 +37,8 @@ resource "azurerm_postgresql_flexible_server" "flexpsql" {
   tags                         = var.tags
   delegated_subnet_id          = var.delegated_subnet_id
   private_dns_zone_id          = try(azurerm_private_dns_zone.flexpsql[0].id, null)
-
+  public_network_access_enabled = var.connectivity_method == "public" ? true : false
+  
   depends_on = [azurerm_private_dns_zone_virtual_network_link.flexpsql]
 
   lifecycle {


### PR DESCRIPTION
This PR adds public_network_access_enabled var to azurerm_postgresql_flexible_server module, derived from the existing connectivity_method var.  No new input variables.  

Testing this with `postgres_servers.default.connectivity_method: private` produced a private flexpsql server as expected.  

Testing with `postgres_servers.default.connectivity_method: public` has not been completed yet