### PR TITLE
fix: (PSKD-903) permissions set in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN yum -y install git openssh jq which curl \
   && curl -sLO https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl \
   && chmod 755 ./kubectl /viya4-iac-azure/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \
-  && chmod g=u -R /etc/passwd /etc/group /viya4-iac-azure \
   && git config --system --add safe.directory /viya4-iac-azure \
-  && terraform init
+  && terraform init \
+  && chmod g=u -R /etc/passwd /etc/group /viya4-iac-azure
 
 ENV TF_VAR_iac_tooling=docker
 ENTRYPOINT ["/viya4-iac-azure/docker-entrypoint.sh"]


### PR DESCRIPTION
## Changes:
"chmod" command in Dockerfile moved after the "terraform init" command to allow for overriding the default local backend.