### PR TITLE
fix: main.tf references to files subdir to include module path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -258,11 +258,11 @@ module "netapp" {
 }
 
 data "external" "git_hash" {
-  program = ["files/tools/iac_git_info.sh"]
+  program = ["${path.module}/files/tools/iac_git_info.sh"]
 }
 
 data "external" "iac_tooling_version" {
-  program = ["files/tools/iac_tooling_version.sh"]
+  program = ["${path.module}/files/tools/iac_tooling_version.sh"]
 }
 
 resource "kubernetes_config_map" "sas_iac_buildinfo" {


### PR DESCRIPTION
Re-opening at the request of Ian

When including the viya4-iac-azure project as a module within a wider terraform codebase, running `terraform apply` creates the following error:

```bash
│ Error: External Program Lookup Failed
│
│   with module.viya4_iac_azure.data.external.git_hash,
│   on .terraform/modules/viya4_iac_azure/main.tf line 274, in data "external" "git_hash":
│  274:   program = ["files/tools/iac_git_info.sh"]
│
│ The data source received an unexpected error while attempting to parse the query. The data source received an unexpected error while attempting to find the program.
│
│ The program must be accessible according to the platform where Terraform is running.
│
│ If the expected program should be automatically found on the platform where Terraform is running, ensure that the program is in an expected directory. On Unix-based platforms, these directories are typically searched based on the '$PATH' environment
│ variable. On Windows-based platforms, these directories are typically searched based on the '%PATH%' environment variable.
│
│ If the expected program is relative to the Terraform configuration, it is recommended that the program name includes the interpolated value of 'path.module' before the program name to ensure that it is compatible with varying module usage. For
│ example: "${path.module}/my-program"
│
│ The program must also be executable according to the platform where Terraform is running. On Unix-based platforms, the file on the filesystem must have the executable bit set. On Windows-based platforms, no action is typically necessary.
│
│ Platform: linux
│ Program: "files/tools/iac_git_info.sh"
│ Error: exec: "files/tools/iac_git_info.sh": stat files/tools/iac_git_info.sh: no such file or directory
╵
╷
│ Error: External Program Lookup Failed
│
│   with module.viya4_iac_azure.data.external.iac_tooling_version,
│   on .terraform/modules/viya4_iac_azure/main.tf line 278, in data "external" "iac_tooling_version":
│  278:   program = ["files/tools/iac_tooling_version.sh"]
│
│ The data source received an unexpected error while attempting to parse the query. The data source received an unexpected error while attempting to find the program.
│
│ The program must be accessible according to the platform where Terraform is running.
│
│ If the expected program should be automatically found on the platform where Terraform is running, ensure that the program is in an expected directory. On Unix-based platforms, these directories are typically searched based on the '$PATH' environment
│ variable. On Windows-based platforms, these directories are typically searched based on the '%PATH%' environment variable.
│
│ If the expected program is relative to the Terraform configuration, it is recommended that the program name includes the interpolated value of 'path.module' before the program name to ensure that it is compatible with varying module usage. For
│ example: "${path.module}/my-program"
│
│ The program must also be executable according to the platform where Terraform is running. On Unix-based platforms, the file on the filesystem must have the executable bit set. On Windows-based platforms, no action is typically necessary.
│
│ Platform: linux
│ Program: "files/tools/iac_tooling_version.sh"
│ Error: exec: "files/tools/iac_tooling_version.sh": stat files/tools/iac_tooling_version.sh: no such file or directory
```

The lines in main.tf, 274 and 278 refer to shell scripts in the files directory using a relative link.

This pull request adds [path.module](https://developer.hashicorp.com/terraform/language/expressions/references#path-module) to the paths in order for it to properly resolve when included as a submodule, or when run as the root module.