### PR TITLE
chore(deps): update default vm generations off v3

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -368,7 +368,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| sku_name| The SKU Name for the PostgreSQL Flexible Server | string | "GP_Standard_D4ds_v5" | The name pattern is the SKU, followed by the tier + family + cores (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3).|
+| sku_name| The SKU Name for the PostgreSQL Flexible Server | string | "GP_Standard_D4ds_v5" | The name pattern is the SKU, followed by the tier + family + cores (e.g. B_Standard_B1ms, GP_Standard_D2s_v5, MO_Standard_E4s_v5).|
 | storage_mb | The max storage allowed for the PostgreSQL Flexible Server | number | 131072 | Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, and 33554432. |
 | backup_retention_days | Backup retention days for the PostgreSQL Flexible server | number | 7 | Supported values are between 7 and 35 days. |
 | geo_redundant_backup_enabled | Enable Geo-redundant or not for server backup | bool | false | Not supported for the basic tier. |

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -64,7 +64,7 @@ node_pools = {
     }
   },
   connect = {
-    "machine_type" = "Standard_E16s_v3"
+    "machine_type" = "Standard_E16s_v5"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -34,14 +34,13 @@ container_registry_admin_enabled    = false
 # AKS config
 kubernetes_version         = "1.29"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "Standard_D4_v3"
-#v3 still has local temp storage
+default_nodepool_vm_type   = "Standard_D4_v5"
 
 # AKS Node Pools config - minimal
 cluster_node_pool_mode = "minimal"
 node_pools = {
   cas = {
-    "machine_type"          = "Standard_E4s_v3"
+    "machine_type"          = "Standard_E4s_v5"
     "os_disk_size"          = 200
     "min_nodes"             = 0
     "max_nodes"             = 5
@@ -52,7 +51,7 @@ node_pools = {
     }
   },
   generic = {
-    "machine_type"          = "Standard_D8s_v3"
+    "machine_type"          = "Standard_D8s_v5"
     "os_disk_size"          = 200
     "min_nodes"             = 0
     "max_nodes"             = 5

--- a/modules/azurerm_postgresql_flex/variables.tf
+++ b/modules/azurerm_postgresql_flex/variables.tf
@@ -17,9 +17,9 @@ variable "server_name" {
 }
 
 variable "sku_name" {
-  description = "The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the tier + name pattern (e.g. B_Standard_B1ms, GP_Standard_D2s_v3, MO_Standard_E4s_v3)."
+  description = "The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the tier + name pattern (e.g. B_Standard_B1ms, GP_Standard_D2s_v5, MO_Standard_E4s_v5)."
   type        = string
-  default     = "GP_Standard_D4s_v3"
+  default     = "GP_Standard_D4s_v5"
 }
 
 variable "storage_mb" {

--- a/modules/azurerm_vm/variables.tf
+++ b/modules/azurerm_vm/variables.tf
@@ -29,7 +29,7 @@ variable "vnet_subnet_id" {
 variable "machine_type" {
   description = "The size which should be used for this Virtual Machine, such as Standard_F2."
   type        = string
-  default     = "Standard_E8s_v3"
+  default     = "Standard_E8s_v5"
 }
 
 variable "vm_admin" {

--- a/variables.tf
+++ b/variables.tf
@@ -289,7 +289,7 @@ variable "postgres_server_defaults" {
   description = ""
   type        = any
   default = {
-    sku_name                     = "GP_Standard_D4s_v3"
+    sku_name                     = "GP_Standard_D4s_v5"
     storage_mb                   = 131072
     backup_retention_days        = 7
     geo_redundant_backup_enabled = false


### PR DESCRIPTION
Fixes #404

The v3 instances are now hidden away in the Microsoft docs under previous and retired generations. The default generation produced by sizing these days are the v5's.

