### PR TITLE
ci: fix tflint github actions

### DIFF
--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -46,6 +46,9 @@ jobs:
         path: ~/.tflint.d/plugins
         key: ubuntu-latest-tflint-${{ hashFiles('.tflint.hcl') }}
 
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+
     - name: Setup TFLint
       uses: terraform-linters/setup-tflint@v3.0.0
       with:

--- a/linting-configs/.tflint.hcl
+++ b/linting-configs/.tflint.hcl
@@ -9,7 +9,7 @@
 
 config {
   # Enables module inspection.
-  module = true
+  call_module_type = "local"
 }
 
 plugin "azurerm" {


### PR DESCRIPTION
Fixes #421 

- Updates to the github action to install terraform before the terraform init command
- update the tflint config setting for module inspection to call local modules, previous parameter failed with the error:

> Run TFLINT_LOG=info tflint --init -c "$(pwd)/linting-configs/.tflint.hcl"
> 23:19:51 config.go:149: [INFO] Load config: /home/runner/work/viya4-iac-azure/viya4-iac-azure/linting-configs/.tflint.hcl
> Failed to load TFLint config; "module" attribute was removed in v0.54.0. Use "call_module_type" instead

the config change follows the example in: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/config.md

Successful action run can be seen at:
https://github.com/Carus11/viya4-iac-azure/actions/runs/12642073422