### PR TITLE
PMFR4PLTFND-1332: netapp_enable_cmk_encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -259,7 +259,7 @@ module "netapp" {
   resource_group_name = local.aks_rg.name
   location            = var.location
   subnet_id           = module.vnet.subnets["netapp"].id
-  network_features    = var.netapp_network_features
+  network_features    = var.netapp_enable_cmk_encryption ? "Standard" : var.netapp_network_features
   service_level       = var.netapp_service_level
   size_in_tb          = var.netapp_size_in_tb
   protocols           = var.netapp_protocols
@@ -269,6 +269,10 @@ module "netapp" {
   depends_on          = [module.vnet]
 
   community_netapp_volume_size = var.community_netapp_volume_size
+
+  netapp_enable_cmk_encryption  = var.netapp_enable_cmk_encryption
+  netapp_cmk_encryption_key_id  = var.netapp_cmk_encryption_key_id
+  netapp_cmk_encryption_key_uai = var.netapp_cmk_encryption_key_uai
 }
 
 data "external" "git_hash" {

--- a/modules/azurerm_netapp/variables.tf
+++ b/modules/azurerm_netapp/variables.tf
@@ -55,6 +55,24 @@ variable "allowed_clients" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "netapp_enable_cmk_encryption" {
+  description = "Setting this variable to true enables CMK encryption on the netapp account.  Only relevant when storage_type=ha."
+  type        = bool
+  default     = false
+}
+
+variable "netapp_cmk_encryption_key_id" {
+  description = "The ID of the key in keyvault to Encrypt ANF with (i.e. https://<keyvault-name>.vault.azure.net/keys/<key-name>).  Must exist before running terraform.  Only relevant when storage_type=ha.  Required if enable_anf_cmk_encryption is true."
+  type        = string
+  default     = null
+}
+
+variable "netapp_cmk_encryption_key_uai" {
+  description = "The user assigned identity that will be used to access the key (i.e. /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uai name>).  Must exist and have Key Vault Crypto Service Encryption User permission on the keyvault before running terraform.  Only relevant when storage_type=ha.  Required if enable_anf_cmk_encryption is true."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Map of tags to be placed on the Resources"
   type        = map(any)

--- a/variables.tf
+++ b/variables.tf
@@ -546,6 +546,24 @@ variable "netapp_network_features" {
   }
 }
 
+variable "netapp_enable_cmk_encryption" {
+  description = "Setting this variable to true enables CMK encryption on the netapp account.  Only relevant when storage_type=ha."
+  type        = bool
+  default     = false
+}
+
+variable "netapp_cmk_encryption_key_id" {
+  description = "The ID of the key in keyvault to Encrypt ANF with (i.e. https://<keyvault-name>.vault.azure.net/keys/<key-name>).  Must exist before running terraform.  Only relevant when storage_type=ha.  Required if enable_anf_cmk_encryption is true."
+  type        = string
+  default     = null
+}
+
+variable "netapp_cmk_encryption_key_uai" {
+  description = "The user assigned identity that will be used to access the key (i.e. /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uai name>).  Must exist and have Key Vault Crypto Service Encryption User permission on the keyvault before running terraform.  Only relevant when storage_type=ha.  Required if enable_anf_cmk_encryption is true."
+  type        = string
+  default     = null
+}
+
 variable "node_pools_availability_zone" {
   description = "Specifies a Availability Zone in which the Kubernetes Cluster Node Pool should be located."
   type        = string


### PR DESCRIPTION
This PR introduces three new variables which should enable CMK encryption on the ANF account.  

```
variable "netapp_enable_cmk_encryption" {
  description = "Setting this variable to true enables CMK encryption on the netapp account.  Only relevant when storage_type=ha."
  type        = bool
  default     = false
}

variable "netapp_cmk_encryption_key_id" {
  description = "The ID of the key in keyvault to Encrypt ANF with (i.e. https://<keyvault-name>.vault.azure.net/keys/<key-name>).  Must exist before running terraform.  Only relevant when storage_type=ha.  Required if enable_anf_cmk_encryption is true."
  type        = string
  default     = null
}

variable "netapp_cmk_encryption_key_uai" {
  description = "The user assigned identity that will be used to access the key (i.e. /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<uai name>).  Must exist and have Key Vault Crypto Service Encryption User permission on the keyvault before running terraform.  Only relevant when storage_type=ha.  Required if enable_anf_cmk_encryption is true."
  type        = string
  default     = null
}
```

The vars are not doc-ed to follow the pattern of other encryption-related vars.  

This should be a non-breaking change.  If netapp_enable_cmk_encryption is false, and/or if the variables are omitted entirely, the ANF module should continue to work exactly as before.  
