### PR TITLE
Adding permission management for BYO networks #450

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -64,6 +64,15 @@ locals {
     : null
   )
 
+  aks_uai_principal_id = (var.aks_identity == "uai"
+    ? (var.aks_uai_name == null
+      ? azurerm_user_assigned_identity.uai[0].principal_id
+      : data.azurerm_user_assigned_identity.uai[0].principal_id
+    )
+    : null
+  )
+
+
   cluster_egress_type = (var.cluster_egress_type == null
     ? (var.egress_public_ip_name == null
       ? "loadBalancer"

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,8 @@ module "vnet" {
   resource_group_name = local.network_rg.name
   location            = var.location
   subnets             = local.subnets
+  roles               = var.msi_network_roles
+  aks_uai_principal_id = local.aks_uai_principal_id
   existing_subnets    = var.subnet_names
   address_space       = [var.vnet_address_space]
   tags                = var.tags

--- a/modules/azurerm_vnet/main.tf
+++ b/modules/azurerm_vnet/main.tf
@@ -58,3 +58,16 @@ resource "azurerm_subnet" "subnet" {
   depends_on = [data.azurerm_virtual_network.vnet, azurerm_virtual_network.vnet]
 }
 
+resource "azurerm_role_assignment" "existing_network_assignment" {
+    count = length(var.existing_subnets) == 0 ? 0 : length(var.roles)
+    scope = data.azurerm_subnet.subnet["aks"].route_table_id
+    role_definition_name = var.roles[count.index]
+    principal_id = var.aks_uai_principal_id
+}
+
+resource "azurerm_role_assignment" "existing_vnet_assignment" {
+  count = var.name == null ? length(var.roles) : 0
+  scope = data.azurerm_virtual_network.vnet[0].id
+  role_definition_name = var.roles[count.index]
+  principal_id = var.aks_uai_principal_id
+}

--- a/modules/azurerm_vnet/variables.tf
+++ b/modules/azurerm_vnet/variables.tf
@@ -61,3 +61,14 @@ variable "tags" {
   description = "The tags to associate with your network and subnets."
   type        = map(string)
 }
+
+variable "roles" {
+    description = "Managed Identity permissions for VNet and Route Table"
+    type = list(string)
+    default = ["Network Contributor"]
+}
+
+variable "aks_uai_principal_id" {
+  description = "Managed Identity Principal ID used to associate permissions to network and route table"
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "use_msi" {
   default     = false
 }
 
+variable "msi_network_roles" {
+    description = "Managed Identity permissions for VNet and Route Table"
+    type = list(string)
+    default = ["Network Contributor"]
+}
+
 variable "iac_tooling" {
   description = "Value used to identify the tooling used to generate this providers infrastructure."
   type        = string


### PR DESCRIPTION
This will add the necessary permissions for a MI created by IaC to any BYO components. It still requires that the SP used has access to manage permissions on the BYO components. #450 