### PR TITLE
ci: update linter to run on pull requests to main and staging

### DIFF
--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -2,6 +2,10 @@ name: Linter Analysis
 on:
   push:
     branches: ['**'] # '*' will cause the workflow to run on all commits to all branches.
+  pull_request:
+    branches:
+    - main
+    - staging
 
 jobs:
   # Hadolint: Job-1

--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -1,7 +1,5 @@
 name: Linter Analysis
 on:
-  push:
-    branches: ['**'] # '*' will cause the workflow to run on all commits to all branches.
   pull_request:
     branches:
     - main


### PR DESCRIPTION
The required linters are not running on pull requests from forked repositories. This fix is intended to trigger the linters on any pull request going to the main or staging branch.

Targeting the main branch so the workflow changes are immediate. Otherwise we will have to wait for the next release.