### PR TITLE
test: (PSKD-1556) add default and non default test for aks_azure_policy_enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ sas_iac_buildinfo.yaml
 .vscode
 test/bin
 test/pkg
-test/test_output
+test/testoutput

--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,7 @@ module "aks" {
   rbac_aad_admin_group_object_ids          = var.rbac_aad_admin_group_object_ids
   aks_private_cluster                      = var.cluster_api_mode == "private" ? true : false
   depends_on                               = [module.vnet]
-  aks_azure_policy_enabled                 = var.aks_azure_policy_enabled
+  aks_azure_policy_enabled                 = var.aks_azure_policy_enabled ? var.aks_azure_policy_enabled : false
 }
 
 module "kubeconfig" {

--- a/test/defaultplan/defaults_test.go
+++ b/test/defaultplan/defaults_test.go
@@ -70,6 +70,12 @@ func TestPlanDefaults(t *testing.T) {
 			AttributeJsonPath: "{$.run_command_enabled}",
 			Message:           "The AKS cluster Run Command feature should be disabled by default",
 		},
+		"azurePolicyEnabledTest": {
+			Expected:          "false",
+			ResourceMapName:   "module.aks.azurerm_kubernetes_cluster.aks",
+			AttributeJsonPath: "{$.azure_policy_enabled}",
+			Message:           "Unexpected azure_policy_enabled value; disabled by default",
+		},
 	}
 
 	helpers.RunTests(t, tests, helpers.GetDefaultPlan(t))

--- a/test/defaultplan/defaults_test.go
+++ b/test/defaultplan/defaults_test.go
@@ -64,13 +64,13 @@ func TestPlanDefaults(t *testing.T) {
 			AssertFunction:    assert.NotEqual,
 			Message:           "The Jump VM machine type should be Standard_B2s",
 		},
-		"runCommandEnabledTest": {
+		"runCommandDefaultTest": {
 			Expected:          "false",
 			ResourceMapName:   "module.aks.azurerm_kubernetes_cluster.aks",
 			AttributeJsonPath: "{$.run_command_enabled}",
 			Message:           "The AKS cluster Run Command feature should be disabled by default",
 		},
-		"azurePolicyEnabledTest": {
+		"azurePolicyDefaultTest": {
 			Expected:          "false",
 			ResourceMapName:   "module.aks.azurerm_kubernetes_cluster.aks",
 			AttributeJsonPath: "{$.azure_policy_enabled}",

--- a/test/nondefaultplan/azure_policy_test.go
+++ b/test/nondefaultplan/azure_policy_test.go
@@ -1,0 +1,30 @@
+// Copyright © 2025, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nondefaultplan
+
+import (
+	"test/helpers"
+	"testing"
+)
+
+// Test the default variables when using the sample-input-defaults.tfvars file
+// with aks_azure_policy_enabled set to "true".
+func TestPlanAzurePolicy(t *testing.T) {
+	t.Parallel()
+
+	variables := helpers.GetDefaultPlanVars(t)
+	variables["aks_azure_policy_enabled"] = true
+
+	tests := map[string]helpers.TestCase{
+		"azurePolicyEnabledTest": {
+			Expected:          "true",
+			ResourceMapName:   "module.aks.azurerm_kubernetes_cluster.aks",
+			AttributeJsonPath: "{$.azure_policy_enabled}",
+			Message:           "Unexpected azure_policy_enabled value",
+		},
+	}
+
+	plan := helpers.GetPlan(t, variables)
+	helpers.RunTests(t, tests, plan)
+}


### PR DESCRIPTION
Adding default and non default unit test case for https://github.com/sassoftware/viya4-iac-azure/pull/389 
- test/defaultplan/defaults_test.go - check aks_azure_policy_enabled returns false
- test/nondefaultplan/azure_policy_test.go - set aks_azure_policy_enabled to true, check returns true

Additional changes:
- main.tf - logic to set aks_azure_policy_enabled to false if not explicitly defined in tfvars file
- defaults_test.go - renaming some tests that make more sense
- .gitignore - fix typo test/test_output to test/testoutput