### PR TITLE
feat: Adding community option for Azure NetappFiles Volume size control.

### DIFF
--- a/docs/community/community_config_vars.md
+++ b/docs/community/community_config_vars.md
@@ -20,5 +20,5 @@ Here is a table with the variables you would use to configure them
 
 | Name | Description | Type | Default | Release Added | Notes |
 | :--- | ---: | ---: | ---: | ---: | ---: |
-| contrib_enable_spot_nodes | Enable spot nodes | bool | false | 10.3.0 | |
-| contrib_netapp_volume_size | Size of the netapp volume | number | 0 | | Zero will disable, must be smaller than the Netapp Pool. The value is given in GB |
+| community_enable_spot_nodes | Enable spot nodes | bool | false | 10.3.0 | |
+| community_netapp_volume_size | Size of the netapp volume | number | 0 | | Zero will disable, must be smaller than the Netapp Pool. The value is given in GB |

--- a/docs/community/community_config_vars.md
+++ b/docs/community/community_config_vars.md
@@ -21,3 +21,4 @@ Here is a table with the variables you would use to configure them
 | Name | Description | Type | Default | Release Added | Notes |
 | :--- | ---: | ---: | ---: | ---: | ---: |
 | contrib_enable_spot_nodes | Enable spot nodes | bool | false | 10.3.0 | |
+| contrib_netapp_volume_size | Size of the netapp volume | number | 0 | | Zero will disable, must be smaller than the Netapp Pool. The value is given in GB |

--- a/docs/community/community_config_vars.md
+++ b/docs/community/community_config_vars.md
@@ -25,7 +25,6 @@ To enable a Spot node pool in your AKS cluster using this module, configure the 
 | Name | Description | Type | Default | Release Added | Notes |
 | :--- | ---: | ---: | ---: | ---: | ---: |
 | community_enable_spot_nodes | Enable spot nodes | bool | false | 10.3.0 | |
-| community_netapp_volume_size | Size of the netapp volume | number | 0 | | Zero will disable, must be smaller than the Netapp Pool. The value is given in GB |
 | community_priority | (Optional) The Priority for Virtual Machines within the Virtual Machine Scale Set that powers this Node Pool. Possible values are Regular and Spot. Defaults to Regular. Changing this forces a new resource to be created. | string | `Regular` | 10.3.0 | Changing this to Spot enables the Spot node pool functionality |
 | community_eviction_policy | (Optional) The Eviction Policy which should be used for Virtual Machines within the Virtual Machine Scale Set powering this Node Pool. Possible values are Deallocate and Delete. Changing this forces a new resource to be created. | string | `Delete` | 10.3.0 | |
 | community_spot_max_price | (Optional) The maximum price you're willing to pay in USD per Virtual Machine. Valid values are -1 (the current on-demand price for a Virtual Machine) or a positive value with up to five decimal places. Changing this forces a new resource to be created. | string | `-1` | 10.3.0 | |

--- a/docs/community/community_config_vars.md
+++ b/docs/community/community_config_vars.md
@@ -8,6 +8,7 @@ Community-contributed configuration variables are listed in the tables below. Th
 ## Table of Contents
 
 * [Spot Nodes](#spot_nodes)
+* [Netapp Volume Size](#netapp_volume_size)
 
 <a name="spot_nodes"></a>
 ## Spot Nodes
@@ -28,3 +29,14 @@ To enable a Spot node pool in your AKS cluster using this module, configure the 
 | community_priority | (Optional) The Priority for Virtual Machines within the Virtual Machine Scale Set that powers this Node Pool. Possible values are Regular and Spot. Defaults to Regular. Changing this forces a new resource to be created. | string | `Regular` | 10.3.0 | Changing this to Spot enables the Spot node pool functionality |
 | community_eviction_policy | (Optional) The Eviction Policy which should be used for Virtual Machines within the Virtual Machine Scale Set powering this Node Pool. Possible values are Deallocate and Delete. Changing this forces a new resource to be created. | string | `Delete` | 10.3.0 | |
 | community_spot_max_price | (Optional) The maximum price you're willing to pay in USD per Virtual Machine. Valid values are -1 (the current on-demand price for a Virtual Machine) or a positive value with up to five decimal places. Changing this forces a new resource to be created. | string | `-1` | 10.3.0 | |
+
+<a name="netapp_volume_size"></a>
+## Netapp Volume Size
+
+Netapp Volume Size control allows you to create a Netapp Volume smaller than the Netapp Pool. This will allow other tools outside of this Terraform to create Netapp Volumes within the pool.
+
+To control the Netapp Volume size use the below community-maintained variable listed below. This will allow you to control the size of the Netapp Volume in GBs. This value must be smaller than the Netapp Pool size. There is no validation for this during the planning phase of Terraform. If this is misconfigured, the Terraform Apply will fail when attempting to deploy the volume.
+
+| Name | Description | Type | Default | Release Added | Notes |
+| :--- | ---: | ---: | ---: | ---: | ---: |
+| community_netapp_volume_size | Size of the netapp volume | number | 0 | 10.3.0 | Zero will disable, must be smaller than the Netapp Pool. The value is given in GB |

--- a/docs/community/community_config_vars.md
+++ b/docs/community/community_config_vars.md
@@ -24,7 +24,6 @@ To enable a Spot node pool in your AKS cluster using this module, configure the 
 
 | Name | Description | Type | Default | Release Added | Notes |
 | :--- | ---: | ---: | ---: | ---: | ---: |
-| community_enable_spot_nodes | Enable spot nodes | bool | false | 10.3.0 | |
 | community_priority | (Optional) The Priority for Virtual Machines within the Virtual Machine Scale Set that powers this Node Pool. Possible values are Regular and Spot. Defaults to Regular. Changing this forces a new resource to be created. | string | `Regular` | 10.3.0 | Changing this to Spot enables the Spot node pool functionality |
 | community_eviction_policy | (Optional) The Eviction Policy which should be used for Virtual Machines within the Virtual Machine Scale Set powering this Node Pool. Possible values are Deallocate and Delete. Changing this forces a new resource to be created. | string | `Delete` | 10.3.0 | |
 | community_spot_max_price | (Optional) The maximum price you're willing to pay in USD per Virtual Machine. Valid values are -1 (the current on-demand price for a Virtual Machine) or a positive value with up to five decimal places. Changing this forces a new resource to be created. | string | `-1` | 10.3.0 | |

--- a/main.tf
+++ b/main.tf
@@ -260,6 +260,8 @@ module "netapp" {
   tags                = var.tags
   allowed_clients     = concat(module.vnet.subnets["aks"].address_prefixes, module.vnet.subnets["misc"].address_prefixes)
   depends_on          = [module.vnet]
+
+  contrib_netapp_volume_size = var.contrib_netapp_volume_size
 }
 
 data "external" "git_hash" {

--- a/main.tf
+++ b/main.tf
@@ -261,7 +261,7 @@ module "netapp" {
   allowed_clients     = concat(module.vnet.subnets["aks"].address_prefixes, module.vnet.subnets["misc"].address_prefixes)
   depends_on          = [module.vnet]
 
-  contrib_netapp_volume_size = var.contrib_netapp_volume_size
+  community_netapp_volume_size = var.community_netapp_volume_size
 }
 
 data "external" "git_hash" {

--- a/modules/azurerm_netapp/main.tf
+++ b/modules/azurerm_netapp/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_netapp_volume" "anf" {
   subnet_id           = var.subnet_id
   network_features    = var.network_features
   protocols           = var.protocols
-  storage_quota_in_gb = var.size_in_tb * 1024
+  storage_quota_in_gb = var.contrib_netapp_volume_size == 0 ? var.size_in_tb * 1024 : var.contrib_netapp_volume_size
   tags                = var.tags
 
   export_policy_rule {

--- a/modules/azurerm_netapp/main.tf
+++ b/modules/azurerm_netapp/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_netapp_volume" "anf" {
   subnet_id           = var.subnet_id
   network_features    = var.network_features
   protocols           = var.protocols
-  storage_quota_in_gb = var.contrib_netapp_volume_size == 0 ? var.size_in_tb * 1024 : var.contrib_netapp_volume_size
+  storage_quota_in_gb = var.community_netapp_volume_size == 0 ? var.size_in_tb * 1024 : var.community_netapp_volume_size
   tags                = var.tags
 
   export_policy_rule {

--- a/modules/azurerm_netapp/variables.tf
+++ b/modules/azurerm_netapp/variables.tf
@@ -59,3 +59,11 @@ variable "tags" {
   description = "Map of tags to be placed on the Resources"
   type        = map(any)
 }
+
+# Community Contribution
+# Netapp Volume Size control
+variable "contrib_netapp_volume_size" {
+  description = "Community Contributed field. Will manually set the value of the Netapp Volume smaller than the Netapp Pool. This value is in GB."
+  type = number
+  default = 0
+}

--- a/modules/azurerm_netapp/variables.tf
+++ b/modules/azurerm_netapp/variables.tf
@@ -62,7 +62,7 @@ variable "tags" {
 
 # Community Contribution
 # Netapp Volume Size control
-variable "contrib_netapp_volume_size" {
+variable "community_netapp_volume_size" {
   description = "Community Contributed field. Will manually set the value of the Netapp Volume smaller than the Netapp Pool. This value is in GB."
   type = number
   default = 0

--- a/variables.tf
+++ b/variables.tf
@@ -831,3 +831,11 @@ variable "node_resource_group_name" {
   type    = string
   default = ""
 }
+
+# Community Contribution
+# Netapp Volume Size control
+variable "contrib_netapp_volume_size" {
+  description = "Community Contributed field. Will manually set the value of the Netapp Volume smaller than the Netapp Pool. This value is in GB."
+  type = number
+  default = 0
+}

--- a/variables.tf
+++ b/variables.tf
@@ -834,7 +834,7 @@ variable "node_resource_group_name" {
 
 # Community Contribution
 # Netapp Volume Size control
-variable "contrib_netapp_volume_size" {
+variable "community_netapp_volume_size" {
   description = "Community Contributed field. Will manually set the value of the Netapp Volume smaller than the Netapp Pool. This value is in GB."
   type = number
   default = 0


### PR DESCRIPTION
Added the option `contrib_netapp_volume_size` a number optional field that will specify an alternative size of the netapp volume created when HA with Netapp Volumes are specified. This is to address #482.

The default value for the field is 0 which when this is specified the volume size will match the pool size which is the current implementation.