### PR TITLE
chore: update workflows to point to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "main"
     open-pull-requests-limit: 2
 
   # Docker dependencies
@@ -18,7 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "main"
     open-pull-requests-limit: 2
 
   # GitHub Actions
@@ -26,5 +26,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "main"
     open-pull-requests-limit: 2

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches:
       - main
-      - staging
 
 jobs:
   validate-pr-title:

--- a/.github/workflows/linter-analysis.yml
+++ b/.github/workflows/linter-analysis.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
     - main
-    - staging
 
 jobs:
   # Hadolint: Job-1


### PR DESCRIPTION
Update workflows that were targeting staging. They will now target the main branch.