### PR TITLE
fix: IaC Azure requires 'temporary_name_for_rotation' during update

### DIFF
--- a/modules/aks_node_pool/main.tf
+++ b/modules/aks_node_pool/main.tf
@@ -28,14 +28,18 @@ resource "azurerm_kubernetes_cluster_node_pool" "autoscale_node_pool" {
   priority                     = var.community_priority
   eviction_policy              = var.community_eviction_policy
   spot_max_price               = var.community_spot_max_price
+  temporary_name_for_rotation  = substr("t${var.node_pool_name}", 0, 12)
 
   lifecycle {
     ignore_changes = [node_count]
   }
 
-  linux_os_config {
-    sysctl_config {
-      vm_max_map_count = try(var.linux_os_config.sysctl_config.vm_max_map_count,null)
+  dynamic "linux_os_config" {
+    for_each = var.linux_os_config[*]
+    content {
+      sysctl_config {
+        vm_max_map_count = var.linux_os_config.sysctl_config.vm_max_map_count
+      }
     }
   }
 }
@@ -64,9 +68,14 @@ resource "azurerm_kubernetes_cluster_node_pool" "static_node_pool" {
   priority                     = var.community_priority
   eviction_policy              = var.community_eviction_policy
   spot_max_price               = var.community_spot_max_price
-  linux_os_config {
-    sysctl_config {
-      vm_max_map_count = try(var.linux_os_config.sysctl_config.vm_max_map_count,null)
+  temporary_name_for_rotation  = substr("t${var.node_pool_name}", 0, 12)
+
+  dynamic "linux_os_config" {
+    for_each = var.linux_os_config[*]
+    content {
+      sysctl_config {
+        vm_max_map_count = var.linux_os_config.sysctl_config.vm_max_map_count
+      }
     }
   }
 }

--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -107,5 +107,9 @@ resource "azurerm_linux_virtual_machine" "vm" {
 
   tags = var.tags
 
+  lifecycle {
+    ignore_changes = [ identity ]
+  }
+
   depends_on = [azurerm_network_interface_security_group_association.vm_nic_sg]
 }


### PR DESCRIPTION
### Changes 
- Only create a `linux_os_config` block for a node pool if a value has been explicitly set for `vm_max_map_count` for that node pool.
- Add `temporary_name_for_rotation` argument to handle changes to the `linux_os_config` value when applied to the same cluster.
- This azure_rm issue https://github.com/hashicorp/terraform-provider-azurerm/issues/29276 requires adding a lifecycle clause to ignore azurerm_vm identity changes until the provider publishes a fix for the issue. This issue is independent of #499 but exposed another problem that we need to account for when running apply against an existing cluster.

### Tests

| Scenario | Method          | Apply Sequence | Provider | K8s Version | vm_max_map_count                     | Notes                                                                                     |
|----------|-----------------|----------------|----------|-------------|---------------------------------------|-------------------------------------------------------------------------------------------|
| 1        | local terraform | OOTB           | Azure    | 1.31.7      | unset for all node pools             | Successful cluster creation                                                              |
| 2        | local terraform | 2nd apply      | Azure    | 1.31.7      | unset for all node pools             | Successful re-apply, no errors                                                           |
| 3        | local terraform | 3rd apply      | Azure    | 1.31.7      | vm_max_map_count set for stateless node pool | Successful re-apply; stateless node re-created; no errors                                 |
| 4        | local terraform | OOTB           | Azure    | 1.31.7      | vm_max_map_count set for stateful and stateless node pools | Successful cluster creation, no errors                                                   |
| 5        | local terraform | 2nd apply      | Azure    | 1.31.7      | vm_max_map_count set for stateful and stateless node pools | Successful re-apply; no errors                                                           |
| 6        | local terraform | 3rd apply      | Azure    | 1.31.7      | vm_max_map_count set only for stateless node pools | Successful re-apply; stateful node re-created; no errors        