### PR TITLE
fix: change aks_pod_cidr based on aks_network_plugin (PSKD-1458)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -148,3 +148,7 @@ output "cluster_node_pool_mode" {
 output "cluster_api_mode" {
   value = var.cluster_api_mode
 }
+
+output "aks_network_plugin" {
+  value = var.aks_network_plugin
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,7 +27,8 @@ output "aks_cluster_password" {
 }
 
 output "aks_pod_cidr" {
-  value = var.aks_pod_cidr
+  # If the aks_network_plugin is set to azure, use the vnet_address_space as the pod CIDR.
+  value = var.aks_network_plugin == "kubenet" ? var.aks_pod_cidr : var.vnet_address_space
 }
 
 # postgres


### PR DESCRIPTION
Update the aks_pod_cidr based on the value of the aks_network_plugin. Currently, if it is set to azure, it will use the wrong aks_pod_cidr which prevents SAS Studio from executing code.

Testing Scenarios:
| Scenario| Provider| K8s version | Deploy Method | aks_network_plugin | Notes |
|--------|--------|--------|--------|--------|---------|
| 1| azure | 1.31.8 | Local tooling | azure | Successful Viya deployment. I was able to execute SAS code in Studio. |
| 2 | azure| 1.31.8 | Local tooling | kubenet | Successful Viya deployment. I was able to execute SAS code in Studio. |