### PR TITLE
fix: update FIPS vm image

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -104,7 +104,7 @@ To enable the FIPS support in your subscription, you first need to accept the le
 To accept the terms please run following az command before deploying cluster:
 
 ```bash
-az vm image terms accept --urn Canonical:0001-com-ubuntu-pro-focal-fips:pro-fips-22_04-gen2:latest --subscription $subscription_id
+az vm image terms accept --urn Canonical:0001-com-ubuntu-pro-jammy-fips:pro-fips-22_04:latest --subscription $subscription_id
 ```
 
 | Name | Description | Type | Default | Notes |

--- a/modules/azurerm_vm/main.tf
+++ b/modules/azurerm_vm/main.tf
@@ -88,14 +88,14 @@ resource "azurerm_linux_virtual_machine" "vm" {
   source_image_reference {
     publisher = var.os_publisher
     offer     = var.fips_enabled ? "0001-com-ubuntu-pro-jammy-fips" : var.os_offer
-    sku       = var.fips_enabled ? "pro-fips-22_04-gen2" : var.os_sku
+    sku       = var.fips_enabled ? "pro-fips-22_04" : var.os_sku
     version   = var.os_version
   }
 
   dynamic "plan" {
     for_each = var.fips_enabled ? [1] : []
     content {
-      name      = "pro-fips-22_04-gen2"
+      name      = "pro-fips-22_04"
       publisher = "canonical"
       product   = "0001-com-ubuntu-pro-jammy-fips"
     }


### PR DESCRIPTION
fixes #506 

Update the FIPS image to the proper "pro-fips-22_04" rather than the invalid "pro-fips-22_04-gen2"

I was able to create a FIPS-enabled cluster and deploy Viya into it.