### PR TITLE
fix: add aks_pod_cidr logic to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -28,7 +28,10 @@ output "aks_cluster_password" {
 
 output "aks_pod_cidr" {
   # If the aks_network_plugin is set to azure, use the aks subnet address space as the pod CIDR.
-  value = var.aks_network_plugin == "kubenet" ? var.aks_pod_cidr : module.vnet.subnets["aks"].address_prefixes[0]
+  value = (
+    var.aks_network_plugin == "kubenet" ||
+    (var.aks_network_plugin == "azure" && var.aks_network_plugin_mode == "overlay")
+  ) ? var.aks_pod_cidr : module.vnet.subnets["aks"].address_prefixes[0]
 }
 
 # postgres


### PR DESCRIPTION
In a previous PR: https://github.com/sassoftware/viya4-iac-azure/pull/519, we added logic that would allow setting of aks_pod_cidr when azure cni w/overlay is chosen.  This PR completes that change by updating outputs.tf with the same logic.  