### PR TITLE
Change from Raid-5 to Raid-0 on NFS

### DIFF
--- a/files/cloud-init/nfs/cloud-config
+++ b/files/cloud-init/nfs/cloud-config
@@ -43,7 +43,7 @@ runcmd:
   #
   - pvcreate $(find /dev/disk/azure/scsi1/ -type l | xargs)
   - vgcreate data-vg01 $(find /dev/disk/azure/scsi1/ -type l | xargs)
-  - lvcreate --type raid5 --extents 100%FREE --stripes 3 --name data-lv01 data-vg01
+  - lvcreate --type raid0 --extents 100%FREE --stripes 4 --stripesize 256 --name data-lv01 data-vg01
   - mkfs -t ext4 /dev/data-vg01/data-lv01
   #
   # Update /etc/fstab


### PR DESCRIPTION
A proposal to replace **Raid-5** with **Raid-0** in Azure.
I understand (and from my performance tests) that Raid-5 may be slightly faster, but managed disks offer 99.999% reliability. 
With Raid-0, we can save 25% on NFS disk costs, which, given terabyte-sized storage, will positively impact cloud costs.
We have Raid-0 with IaC-AWS.

MS Doc:
https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#high-durability-and-availability