### PR TITLE
fix: when ACR is enabled automatically setup acr pull permission

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -403,7 +403,8 @@ For complete recovery procedures, see [Multi-ZoneDeploymentGuide.md](user/Multi-
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| create_container_registry| Create container registry instance | bool | false | |
+| create_container_registry| Create container registry instance | bool | false | When enabled, an `AcrPull` role assignment is automatically created for the AKS kubelet identity. |
+| container_registry_name | Suffix appended between the prefix and 'acr' in the registry name for global uniqueness | string | "" | Resulting name: `<prefix><container_registry_name>acr`. ACR names must be globally unique. |
 | container_registry_sku | Service tier for the registry | string | "Standard" | Possible values: "Basic", "Standard", "Premium" |
 | container_registry_admin_enabled | Enables the admin user | bool | false | |
 | container_registry_geo_replica_locs | List of Azure locations where the container registry should be geo-replicated. | list of strings | null | This is only supported when `container_registry_sku` is set to `"Premium"`. |

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -48,8 +48,8 @@ terraform import -var-file=sample-input.tfvars -state=terraform.tfstate module.n
 ```bash
 Error: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client 'REDACTED' with object id 'REDACTED' does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/REDACTED/resourceGroups/viya-tst-rg/providers/Microsoft.ContainerRegistry/registries/viyatstacr/providers/Microsoft.Authorization/roleAssignments/REDACTED' or the scope is invalid. If access was recently granted, please refresh your credentials."
 
-  on modules/azurerm_container_registry/main.tf line 18, in resource "azurerm_role_assignment" "acr":
-  18: resource "azurerm_role_assignment" "acr" {
+  on main.tf line 119, in resource "azurerm_role_assignment" "acr_pull":
+  119: resource "azurerm_role_assignment" "acr_pull" {
 ```
 
 ### Resolution:

--- a/docs/user/AzureHelpTopics.md
+++ b/docs/user/AzureHelpTopics.md
@@ -82,9 +82,11 @@ To learn more about how Azure Role-Based Access Control works, refer to the foll
 * [Add or remove roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli#user-at-a-subscription-scope)
 
 
-## How to Grant a Service Principal Access to the Azure Container Registry
+## AKS Access to the Azure Container Registry
 
-When creating a private Azure Container Registry, assign 'acrpull' role to the Service Principal:
+When `create_container_registry` is set to `true`, an `AcrPull` role assignment is automatically created for the AKS kubelet managed identity. This allows the AKS cluster to pull images from the ACR without additional manual configuration.
+
+If you are using a pre-existing ACR (not managed by this project), you can manually assign the `acrpull` role to the Service Principal:
 
 ```bash
   ACR_ID=$(terraform output cr_id)

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -41,6 +41,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-cilium.tfvars
+++ b/examples/sample-input-cilium.tfvars
@@ -30,6 +30,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -30,6 +30,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -28,6 +28,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -28,6 +28,7 @@ tags = {} # for example: { "owner|email" = "<you>@<domain>.<com>", "key1" = "val
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-multizone-enhanced.tfvars
+++ b/examples/sample-input-multizone-enhanced.tfvars
@@ -40,6 +40,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-multizone.tfvars
+++ b/examples/sample-input-multizone.tfvars
@@ -55,6 +55,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-optionalcas.tfvars
+++ b/examples/sample-input-optionalcas.tfvars
@@ -28,6 +28,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-postgres.tfvars
+++ b/examples/sample-input-postgres.tfvars
@@ -82,6 +82,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-ppg.tfvars
+++ b/examples/sample-input-ppg.tfvars
@@ -29,6 +29,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -30,6 +30,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -30,6 +30,7 @@ postgres_servers = {
 
 # Azure Container Registry config
 create_container_registry           = false
+container_registry_name             = ""
 container_registry_sku              = "Standard"
 container_registry_admin_enabled    = false
 

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ module "vnet" {
 
 resource "azurerm_container_registry" "acr" {
   count               = var.create_container_registry ? 1 : 0
-  name                = join("", regexall("[a-zA-Z0-9]+", "${var.prefix}acr")) # alpha numeric characters only are allowed
+  name                = join("", regexall("[a-zA-Z0-9]+", "${var.prefix}${var.container_registry_name}acr")) # alpha numeric characters only are allowed
   resource_group_name = local.aks_rg.name
   location            = var.location
   sku                 = local.container_registry_sku
@@ -114,6 +114,14 @@ resource "azurerm_container_registry" "acr" {
     }
   }
   tags = var.tags
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  count                            = var.create_container_registry ? 1 : 0
+  principal_id                     = module.aks.kubelet_identity_object_id
+  role_definition_name             = "AcrPull"
+  scope                            = azurerm_container_registry.acr[0].id
+  skip_service_principal_aad_check = true
 }
 
 resource "azurerm_network_security_rule" "acr" {

--- a/modules/azure_aks/outputs.tf
+++ b/modules/azure_aks/outputs.tf
@@ -40,3 +40,7 @@ output "cluster_public_ip" {
 output "name" {
   value = azurerm_kubernetes_cluster.aks.name
 }
+
+output "kubelet_identity_object_id" {
+  value = try(azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -547,6 +547,12 @@ variable "create_container_registry" {
   default     = false
 }
 
+variable "container_registry_name" {
+  description = "Suffix appended to the ACR name between the prefix and 'acr' to ensure global uniqueness. The resulting name is '<prefix><container_registry_name>acr'."
+  type        = string
+  default     = ""
+}
+
 variable "container_registry_sku" {
   description = "The SKU name of the container registry. Possible values are `Basic`, `Standard` and `Premium`."
   type        = string


### PR DESCRIPTION
Fixes #400 
This change automatically sets up acr pull permission from the kubernetes cluster. This aligns with current security guidelines of not using static credentials (a docker login secret), and the other principal of secure by default. 
Additionally it introduces a parameter to name the acr, to help ensure global uniqueness. Previously there were some global uniqueness problems using only `{prefix}acr`. 